### PR TITLE
Improve intro guidance on inicio page

### DIFF
--- a/inicio.html
+++ b/inicio.html
@@ -3,24 +3,23 @@
     <section class="hero-section">
         <div class="hero-content">
             <h1 class="text-5xl md:text-7xl font-bold">Maratón Internacional Acapulco</h1>
-            <p class="text-2xl mt-4">Gracias por acompañarnos en la edición 2024</p>
+            <p class="text-2xl mt-4">Sitio oficial del maratón de aguas abiertas en la Bahía de Santa Lucía</p>
         </div>
     </section>
 
     <!-- Sección de Información y Requisitos -->
     <section class="pt-16 pb-8">
         <div class="max-w-4xl mx-auto bg-gray-800 p-8 rounded-lg text-left -mt-40 md:-mt-32 relative z-10 shadow-2xl">
-            <p class="mb-4">
-                Más de 1,500 nadadores cruzaron las aguas de la Bahía de Santa Lucía para honrar la tradición guadalupana, celebrar la resiliencia de Acapulco y sumar una nueva página a la historia del maratón de aguas abiertas más longevo del país.
+            <p class="mb-4 text-lg">
+                Bienvenido al sitio oficial: aquí encuentras la cronología, los resultados y todo lo que necesitas para vivir el Maratón Internacional Acapulco.
             </p>
             <p class="mb-4 text-gray-300">
-                Estamos preparando la próxima convocatoria y actualizando el archivo histórico. Mientras tanto, revive lo mejor de la edición pasada y consulta tu desempeño en la sección de resultados.
+                Es una travesía de aguas abiertas por la Bahía de Santa Lucía que honra la tradición guadalupana y celebra el nado en mar abierto con nadadores de todo el país.
             </p>
-            <h3 class="text-2xl font-bold text-green-400 mt-6 mb-4">¿Qué sigue?</h3>
-            <ul class="list-disc list-inside text-gray-300 space-y-2">
-                <li>Publicaremos fechas, categorías y rutas 2025 en las próximas semanas.</li>
-                <li>La consulta de resultados históricos y cronologías ya está disponible para todos los competidores.</li>
-                <li>Sigue nuestras redes sociales para enterarte del lanzamiento de inscripciones.</li>
+            <ul class="list-disc list-inside space-y-2 text-gray-200">
+                <li>Revisa rutas y distancias para elegir tu desafío (1 km o 5 km).</li>
+                <li>Consulta la cronología histórica y los resultados más recientes.</li>
+                <li>Infórmate sobre la próxima edición y la logística de salida y llegada.</li>
             </ul>
             <div class="text-center mt-8 flex flex-wrap justify-center gap-4">
                 <a data-target="cronologia.html" class="bg-green-500 text-white px-6 py-3 rounded-lg hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-400 font-bold cursor-pointer">
@@ -28,6 +27,9 @@
                 </a>
                 <a data-target="resultados.html" class="bg-blue-500 text-white px-6 py-3 rounded-lg hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-400 font-bold cursor-pointer">
                     Busca tus resultados
+                </a>
+                <a data-target="convocatoria.html" class="bg-yellow-500 text-gray-900 px-6 py-3 rounded-lg hover:bg-yellow-400 focus:outline-none focus:ring-2 focus:ring-yellow-300 font-bold cursor-pointer">
+                    Ver convocatoria
                 </a>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- expand intro copy to clarify the official site purpose and highlight the open-water tradition
- add quick bullet points about rutas, cronología, y logística
- include a direct call to action to revisar la convocatoria

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d82244f44832c860295385b59a7b6)