### PR TITLE
Add Strava-style participant detail view for results

### DIFF
--- a/resultados.html
+++ b/resultados.html
@@ -16,4 +16,37 @@
     <div id="resultsContainer" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         <!-- Los resultados de la búsqueda se insertarán aquí -->
     </div>
+
+    <!-- Panel detallado del participante al estilo Strava -->
+    <div id="participantDetail" class="mt-10 bg-gray-900/70 backdrop-blur rounded-xl border border-gray-800 p-6 hidden">
+        <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
+            <div class="space-y-1">
+                <p class="text-xs uppercase tracking-wide text-green-400">Perfil</p>
+                <h3 id="detailName" class="text-2xl font-bold">Selecciona un participante</h3>
+                <p id="detailMeta" class="text-sm text-gray-400">Aquí verás sus participaciones, posiciones y evolución.</p>
+            </div>
+            <button id="closeParticipantDetail" class="px-3 py-2 text-sm bg-gray-800 rounded-lg hover:bg-gray-700">Cerrar</button>
+        </div>
+
+        <div class="grid md:grid-cols-3 gap-4 mb-4">
+            <div class="col-span-2 space-y-2">
+                <p class="text-xs text-gray-400">Filtro por categoría/edad</p>
+                <select id="detailCategoryFilter" class="w-full bg-gray-800 text-white p-3 rounded-lg">
+                    <option value="">Todas las categorías</option>
+                </select>
+            </div>
+            <div class="space-y-2">
+                <p class="text-xs text-gray-400">Distancia</p>
+                <select id="detailDistanceFilter" class="w-full bg-gray-800 text-white p-3 rounded-lg">
+                    <option value="">Todas</option>
+                    <option value="1K">1K</option>
+                    <option value="5K">5K</option>
+                </select>
+            </div>
+        </div>
+
+        <div id="detailContent" class="space-y-4 text-sm text-gray-300">
+            <p class="text-gray-400">Haz clic en un participante para ver sus resultados desglosados por distancia y filtra sus categorías.</p>
+        </div>
+    </div>
 </div>


### PR DESCRIPTION
## Summary
- add Strava-inspired participant detail panel with category and distance filters on the resultados page
- show category trajectory (primera y última) directly on participant cards
- enable distance-specific breakdowns (1K/5K/otras) with interactive controls and close action

## Testing
- not run (static changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693da64c9be4832c89b61145837d942f)