### PR TITLE
Simplify participant results cards

### DIFF
--- a/resultados.html
+++ b/resultados.html
@@ -3,13 +3,23 @@
     <p class="mb-6">Ingresa tu nombre para ver todos tus resultados a lo largo de los años.</p>
 
     <!-- Campo de Búsqueda -->
-    <div class="mb-8">
-        <input 
-            type="text" 
-            id="searchInput"
-            placeholder="Ingresa tu nombre completo..." 
-            class="w-full max-w-lg p-3 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400"
-        />
+    <div class="mb-8 flex flex-col items-center gap-3">
+        <div class="w-full max-w-2xl flex flex-col sm:flex-row gap-3">
+            <input
+                type="text"
+                id="searchInput"
+                placeholder="Ingresa tu nombre completo..."
+                class="flex-1 p-3 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400"
+            />
+            <button
+                id="searchButton"
+                class="px-5 py-3 bg-green-500 text-gray-900 font-semibold rounded-lg hover:bg-green-400 transition"
+                type="button"
+            >
+                Buscar
+            </button>
+        </div>
+        <p class="text-sm text-gray-400">Escribe al menos 6 caracteres y presiona "Buscar" para ver coincidencias.</p>
     </div>
 
     <!-- Contenedor para mostrar los resultados -->
@@ -30,9 +40,9 @@
 
         <div class="grid md:grid-cols-3 gap-4 mb-4">
             <div class="col-span-2 space-y-2">
-                <p class="text-xs text-gray-400">Filtro por categoría/edad</p>
+                <p class="text-xs text-gray-400">Filtro por edad</p>
                 <select id="detailCategoryFilter" class="w-full bg-gray-800 text-white p-3 rounded-lg">
-                    <option value="">Todas las categorías</option>
+                    <option value="">Todas las edades</option>
                 </select>
             </div>
             <div class="space-y-2">
@@ -46,7 +56,7 @@
         </div>
 
         <div id="detailContent" class="space-y-4 text-sm text-gray-300">
-            <p class="text-gray-400">Haz clic en un participante para ver sus resultados desglosados por distancia y filtra sus categorías.</p>
+            <p class="text-gray-400">Haz clic en un participante para ver sus resultados desglosados por distancia y filtra por edad.</p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- sanitize event parsing to remove `id=` artifacts and keep maratón labels readable
- simplify resultados cards to show solo datos del participante y abrir el detalle completo al hacer clic
- reenfocar filtros y copias del panel detallado en edades y distancias, usando el nuevo botón "Ver detalle"

## Testing
- python -m json.tool assets/data/history_results.json > /dev/null
- python -m json.tool assets/data/participants.json > /dev/null

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693daa3be568832c91a6b03432c21890)