### PR TITLE
Refine participant cards and event labels

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -13,7 +13,7 @@ const extractYearFromEvent = (eventString = '') => {
 };
 
 const parseEventInfo = (eventString = '') => {
-    const eventPattern = /id=(\d+)_([\d]+)_maraton_acapulco_(\d{4})/i;
+    const eventPattern = /id=(\d+)_([\d]+)_mara[tó]n_acapulco_(\d{4})/i;
     const match = eventString.match(eventPattern);
 
     if (match) {
@@ -22,16 +22,21 @@ const parseEventInfo = (eventString = '') => {
             eventId,
             edition,
             year,
-            label: `${edition} Maratón ${year}`
+            label: `${edition} Maratón Acapulco ${year}`
         };
     }
 
+    const sanitizedEvent = eventString
+        .replace(/^id=/i, '')
+        .replace(/^\d+_?/, '')
+        .replace(/_/g, ' ')
+        .trim();
     const year = extractYearFromEvent(eventString);
     return {
-        eventId: eventString || null,
+        eventId: sanitizedEvent || null,
         edition: null,
         year,
-        label: eventString || 'Evento no especificado'
+        label: sanitizedEvent || 'Evento no especificado'
     };
 };
 
@@ -184,8 +189,8 @@ async function setupResultsPage() {
         });
 
         const categories = sortedByYear
-            .map(record => record.category)
-            .filter(Boolean);
+            .map(record => deriveAgeGroup(record))
+            .filter(age => age && age !== 'Sin registro');
 
         if (!categories.length) return null;
 
@@ -330,69 +335,19 @@ async function setupResultsPage() {
             }
 
             resultsContainer.innerHTML = dataToRender.map(result => {
-                const groupedRecords = groupRecordsByEvent(result.records);
-
                 return `
-                    <div class="card text-left space-y-4" data-competitor-key="${result.key}">
+                    <div class="card text-left space-y-4 cursor-pointer hover:border-green-400" data-competitor-key="${result.key}">
                         <div class="space-y-1">
                             <p class="text-xs uppercase tracking-wide text-green-400">Competidor</p>
                             <h3 class="text-2xl font-bold">${result.name}</h3>
-                            <p class="text-sm text-gray-300">${result.origin}</p>
-                            <p class="text-sm text-gray-400">${result.team}</p>
-                            <p class="text-xs text-gray-500">Participaciones: ${result.records.length}</p>
-                            <p class="text-xs text-gray-500">Sexo: ${result.gender || 'N/D'} · ${(() => {
-                                const categoryRange = getCategoryRange(result.records);
-                                if (categoryRange?.hasRange) {
-                                    return `Categorías: ${categoryRange.first} → ${categoryRange.last}`;
-                                }
-                                if (categoryRange?.first) {
-                                    return `Categoría: ${categoryRange.first}`;
-                                }
-                                return `Categoría: ${result.ageGroup || 'N/D'}`;
-                            })()}</p>
+                            <p class="text-sm text-gray-500">Sexo: ${result.gender || 'N/D'}</p>
+                            <p class="text-sm text-gray-500">Participaciones: ${result.records.length}</p>
                         </div>
                         ${result.records.length === 0 ? `
                             <div class="bg-gray-900 rounded-lg p-4 text-sm text-gray-400">
                                 Aún no registramos resultados históricos para este participante.
                             </div>
-                        ` : `
-                            <button class="w-full px-4 py-2 bg-green-500 text-gray-900 font-semibold rounded-lg hover:bg-green-400 transition view-participant">Ver detalle al estilo Strava</button>
-                            <div class="space-y-3">
-                                ${groupedRecords.map(group => `
-                                    <div class="bg-gray-900 rounded-lg p-3 space-y-2">
-                                        <div class="flex flex-wrap justify-between items-center gap-2">
-                                            <p class="text-lg font-semibold text-green-400">${group.label}</p>
-                                            <span class="text-sm font-bold">${group.items.length} participación${group.items.length !== 1 ? 'es' : ''}</span>
-                                        </div>
-                                        <div class="space-y-3">
-                                            ${group.items.map(record => `
-                                                <div class="bg-gray-800 rounded-lg p-3 space-y-2">
-                                                    <div class="flex flex-wrap justify-between items-center gap-2">
-                                                        <p class="text-base font-semibold">${record.year} · ${record.distance}</p>
-                                                        <span class="text-sm font-bold">${record.time}</span>
-                                                    </div>
-                                                    <p class="text-sm"><strong>Categoría:</strong> ${record.category}</p>
-                                                    <div class="grid grid-cols-3 gap-2 text-center text-xs">
-                                                        <div class="bg-gray-900 rounded-md py-2">
-                                                            <p class="text-gray-400">Cat.</p>
-                                                            <p class="text-base font-bold">${record.positionCategory}</p>
-                                                        </div>
-                                                        <div class="bg-gray-900 rounded-md py-2">
-                                                            <p class="text-gray-400">Rama</p>
-                                                            <p class="text-base font-bold">${record.positionGender}</p>
-                                                        </div>
-                                                        <div class="bg-gray-900 rounded-md py-2">
-                                                            <p class="text-gray-400">Gral.</p>
-                                                            <p class="text-base font-bold">${record.positionGeneral}</p>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            `).join('')}
-                                        </div>
-                                    </div>
-                                `).join('')}
-                            </div>
-                        `}
+                        ` : ''}
                     </div>
                 `;
             }).join('');
@@ -469,15 +424,15 @@ async function setupResultsPage() {
                 ? `${categoryRange.first} → ${categoryRange.last}`
                 : (categoryRange?.first || participant.ageGroup || 'N/D');
 
-            detailMeta.textContent = `Participaciones: ${participant.records.length} · Procedencia: ${participant.origin || 'N/D'} · Categoría/Edad: ${categorySummary}`;
+            detailMeta.textContent = `Participaciones: ${participant.records.length} · Procedencia: ${participant.origin || 'N/D'} · Edad: ${categorySummary}`;
 
-            const availableCategories = Array.from(new Set(participant.records
-                .map(record => record.category)
-                .filter(Boolean)));
+            const availableAgeGroups = Array.from(new Set(participant.records
+                .map(record => deriveAgeGroup(record))
+                .filter(age => age && age !== 'Sin registro')));
 
             if (detailCategoryFilter) {
-                detailCategoryFilter.innerHTML = '<option value="">Todas las categorías</option>' +
-                    availableCategories.map(category => `<option value="${category}">${category}</option>`).join('');
+                detailCategoryFilter.innerHTML = '<option value="">Todas las edades</option>' +
+                    availableAgeGroups.map(age => `<option value="${age}">${age}</option>`).join('');
                 detailCategoryFilter.value = '';
             }
             if (detailDistanceFilter) {
@@ -490,7 +445,8 @@ async function setupResultsPage() {
                 const distanceFilter = detailDistanceFilter?.value || '';
 
                 const filtered = selectedParticipant.records.filter(record => {
-                    const matchesCategory = categoryFilter ? record.category === categoryFilter || (record.ageGroup && record.ageGroup.includes(categoryFilter)) : true;
+                    const recordAge = deriveAgeGroup(record);
+                    const matchesCategory = categoryFilter ? recordAge === categoryFilter : true;
                     const normalizedDistance = normalizeDistanceLabel(record.distance);
                     const matchesDistance = distanceFilter ? normalizedDistance === distanceFilter : true;
                     return matchesCategory && matchesDistance;
@@ -571,14 +527,13 @@ async function setupResultsPage() {
         };
 
         resultsContainer.addEventListener('click', (event) => {
-            const actionButton = event.target.closest('.view-participant');
             const card = event.target.closest('[data-competitor-key]');
-            if (actionButton && card) {
-                const key = card.getAttribute('data-competitor-key');
-                const participant = combinedData.find(item => item.key === key);
-                if (participant) {
-                    renderParticipantDetail(participant);
-                }
+            if (!card) return;
+
+            const key = card.getAttribute('data-competitor-key');
+            const participant = combinedData.find(item => item.key === key);
+            if (participant) {
+                renderParticipantDetail(participant);
             }
         });
     } catch (error) {

--- a/resultados.html
+++ b/resultados.html
@@ -40,9 +40,9 @@
 
         <div class="grid md:grid-cols-3 gap-4 mb-4">
             <div class="col-span-2 space-y-2">
-                <p class="text-xs text-gray-400">Filtro por categoría/edad</p>
+                <p class="text-xs text-gray-400">Filtro por edad</p>
                 <select id="detailCategoryFilter" class="w-full bg-gray-800 text-white p-3 rounded-lg">
-                    <option value="">Todas las categorías</option>
+                    <option value="">Todas las edades</option>
                 </select>
             </div>
             <div class="space-y-2">


### PR DESCRIPTION
## Summary
- remove the standalone detail button so participant cards stay minimal and fully clickable
- sanitize event labels further and include the Acapulco name to avoid showing raw ids

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693db23eadf4832c894c75d12a149b53)