### PR TITLE
Add carousel pagination to resultados listing

### DIFF
--- a/resultados.html
+++ b/resultados.html
@@ -27,6 +27,24 @@
         <!-- Los resultados de la búsqueda se insertarán aquí -->
     </div>
 
+    <div id="resultsNavigation" class="hidden flex items-center justify-center gap-4 mt-6">
+        <button
+            id="prevResults"
+            type="button"
+            class="px-4 py-2 bg-gray-800 text-gray-200 rounded-lg border border-gray-700 disabled:opacity-50 disabled:cursor-not-allowed hover:border-green-400"
+        >
+            Anterior
+        </button>
+        <span id="resultsPageIndicator" class="text-sm text-gray-400"></span>
+        <button
+            id="nextResults"
+            type="button"
+            class="px-4 py-2 bg-gray-800 text-gray-200 rounded-lg border border-gray-700 disabled:opacity-50 disabled:cursor-not-allowed hover:border-green-400"
+        >
+            Siguiente
+        </button>
+    </div>
+
     <!-- Panel detallado del participante al estilo Strava -->
     <div id="participantDetail" class="mt-10 bg-gray-900/70 backdrop-blur rounded-xl border border-gray-800 p-6 hidden">
         <div class="flex flex-wrap items-center justify-between gap-4 mb-6">


### PR DESCRIPTION
## Summary
- add navigation controls to resultados page for paginated viewing
- paginate search results into 10-participant windows with next/previous controls
- hide navigation when searches are too short or data fails to load

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693db8cf6fb0832c883aedd50c90a698)