### PR TITLE
Improve participant detail info and event titles

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -141,6 +141,8 @@ async function setupResultsPage() {
     const detailContent = document.getElementById('detailContent');
     const detailName = document.getElementById('detailName');
     const detailMeta = document.getElementById('detailMeta');
+    const detailOrigin = document.getElementById('detailOrigin');
+    const detailTeam = document.getElementById('detailTeam');
     const detailCategoryFilter = document.getElementById('detailCategoryFilter');
     const detailDistanceFilter = document.getElementById('detailDistanceFilter');
     const closeDetailButton = document.getElementById('closeParticipantDetail');
@@ -306,7 +308,7 @@ async function setupResultsPage() {
                 if (!existing.gender || existing.gender === '—') {
                     existing.gender = participantInfo.gender;
                 }
-                if (!existing.ageGroup || existing.ageGroup === '—') {
+                if (participantInfo.ageGroup && participantInfo.ageGroup !== '—') {
                     existing.ageGroup = participantInfo.ageGroup;
                 }
                 updateSearchIndex(existing);
@@ -489,13 +491,20 @@ async function setupResultsPage() {
             selectedParticipant = participant;
             participantDetail.classList.remove('hidden');
             detailName.textContent = participant.name;
+            if (detailOrigin) {
+                detailOrigin.textContent = participant.origin || 'N/D';
+            }
+            if (detailTeam) {
+                detailTeam.textContent = participant.team || 'Sin equipo';
+            }
 
             const categoryRange = getCategoryRange(participant.records);
+            const catalogAge = participant.ageGroup && participant.ageGroup !== '—' ? participant.ageGroup : null;
             const categorySummary = categoryRange?.hasRange
                 ? `${categoryRange.first} → ${categoryRange.last}`
-                : (categoryRange?.first || participant.ageGroup || 'N/D');
+                : (categoryRange?.first || 'N/D');
 
-            detailMeta.textContent = `Participaciones: ${participant.records.length} · Procedencia: ${participant.origin || 'N/D'} · Edad: ${categorySummary}`;
+            detailMeta.textContent = `Participaciones: ${participant.records.length} · Procedencia: ${participant.origin || 'N/D'} · Edad: ${catalogAge || categorySummary}`;
 
             const availableAgeGroups = Array.from(new Set(participant.records
                 .map(record => deriveAgeGroup(record))
@@ -551,7 +560,7 @@ async function setupResultsPage() {
                                     <div class="bg-gray-800/60 rounded-lg p-3">
                                         <div class="flex flex-wrap items-center justify-between gap-2">
                                             <div>
-                                                <p class="text-base font-semibold">${record.year} · ${record.event}</p>
+                                                <p class="text-base font-semibold">${record.year} · ${record.eventEdition ? `${record.eventEdition} Maratón Acapulco` : record.event}</p>
                                                 <p class="text-xs text-gray-400">Categoría: ${record.category}</p>
                                             </div>
                                             <p class="text-lg font-bold text-green-400">${record.time}</p>

--- a/resultados.html
+++ b/resultados.html
@@ -49,6 +49,10 @@
     <div id="participantDetail" class="mt-10 bg-gray-900/70 backdrop-blur rounded-xl border border-gray-800 p-6 hidden">
         <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
             <div class="space-y-1">
+                <div class="flex flex-wrap gap-2 text-xs text-gray-400">
+                    <span class="px-2 py-1 bg-gray-800 rounded-full">Estado: <span id="detailOrigin">N/D</span></span>
+                    <span class="px-2 py-1 bg-gray-800 rounded-full">Equipo: <span id="detailTeam">N/D</span></span>
+                </div>
                 <p class="text-xs uppercase tracking-wide text-green-400">Perfil</p>
                 <h3 id="detailName" class="text-2xl font-bold">Selecciona un participante</h3>
                 <p id="detailMeta" class="text-sm text-gray-400">Aquí verás sus participaciones, posiciones y evolución.</p>


### PR DESCRIPTION
## Summary
- add origin and team badges to the participant detail header
- prefer participant catalog age categories for the detail summary
- prevent duplicated years in event titles within result cards

## Testing
- not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dd363735c832c8a3b39c06405404f)