### PR TITLE
Improve chronology event filter matching

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -40,6 +40,18 @@ const parseEventInfo = (eventString = '') => {
     };
 };
 
+const buildEventKey = (eventInfo, fallback = '') => {
+    if (eventInfo?.eventId) {
+        return `${eventInfo.eventId}-${eventInfo.year || 'nd'}`;
+    }
+
+    if (eventInfo?.label) {
+        return normalizeText(`${eventInfo.label}-${eventInfo.year || ''}`);
+    }
+
+    return normalizeText(fallback);
+};
+
 const buildCompetitorKey = (id, name) => {
     if (id) return normalizeText(id);
     return normalizeText(name || '');
@@ -72,6 +84,7 @@ let oneKGenderChartInstance = null;
 let oneKAgeChartInstance = null;
 let oneKTimeChartInstance = null;
 let yearTrendChartInstance = null;
+let chronologyTimeChartInstance = null;
 
 document.addEventListener('DOMContentLoaded', () => {
     const links = document.querySelectorAll('nav a[data-target]'); // Selecciona todos los enlaces del nav
@@ -743,14 +756,21 @@ const normalizeRecordForStats = (record) => {
     const genderRaw = record.sexo || record.gender || 'No especificado';
     const gender = genderRaw.toString().trim().toUpperCase();
 
+    const eventName = record.evento || record.event || 'Evento no especificado';
+    const eventInfo = parseEventInfo(eventName);
+    const category = record.categoria || record.category || 'Categoría N/D';
+
     return {
         participantKey: buildParticipantKey(record.participant_id || record.participantId, record.nombre_completo || record.name),
         name: record.nombre_completo || record.name || 'Sin nombre',
         gender,
         ageGroup: deriveAgeGroup(record),
         distance: distanceLabel,
+        category,
+        event: eventInfo.label,
+        eventKey: buildEventKey(eventInfo, eventName),
         timeMinutes: parseResultTimeInMinutes(record),
-        year: extractYearFromEvent(record.evento || record.event || '')
+        year: eventInfo.year
     };
 };
 
@@ -806,6 +826,21 @@ const aggregateGenderDistribution = (records) => {
         acc[key] = (acc[key] || 0) + 1;
         return acc;
     }, {});
+};
+
+const summarizeGenderCounts = (records) => {
+    const distribution = aggregateGenderDistribution(records);
+    const femaleCount = Object.entries(distribution)
+        .filter(([gender]) => normalizeText(gender).startsWith('fe'))
+        .reduce((sum, [, count]) => sum + count, 0);
+
+    const maleCount = Object.entries(distribution)
+        .filter(([gender]) => normalizeText(gender).includes('var') || normalizeText(gender).startsWith('ma'))
+        .reduce((sum, [, count]) => sum + count, 0);
+
+    const total = Object.values(distribution).reduce((sum, value) => sum + value, 0);
+
+    return { femaleCount, maleCount, total };
 };
 
 const aggregateAgeDistribution = (records) => {
@@ -913,6 +948,59 @@ const renderAgeChart = (ageGroups) => {
                     labels: {
                         color: '#e2e8f0'
                     }
+                }
+            }
+        }
+    });
+};
+
+const renderChronologyAgeChart = (records) => {
+    const canvas = document.getElementById('chronologyAgeChart');
+    if (!canvas) return;
+
+    const distribution = aggregateAgeDistribution(records);
+    const labels = Object.keys(distribution);
+    if (!labels.length) {
+        canvas.replaceWith(createEmptyState('Sin datos de edad disponibles.'));
+        return;
+    }
+
+    const sortedLabels = labels.sort((a, b) => {
+        const aNum = parseInt(a, 10);
+        const bNum = parseInt(b, 10);
+        if (Number.isNaN(aNum) && Number.isNaN(bNum)) return a.localeCompare(b);
+        if (Number.isNaN(aNum)) return 1;
+        if (Number.isNaN(bNum)) return -1;
+        return aNum - bNum;
+    });
+
+    const counts = sortedLabels.map(label => distribution[label]);
+
+    if (ageDistributionChart) {
+        ageDistributionChart.destroy();
+    }
+
+    ageDistributionChart = new Chart(canvas.getContext('2d'), {
+        type: 'bar',
+        data: {
+            labels: sortedLabels,
+            datasets: [{
+                label: 'Participantes',
+                data: counts,
+                backgroundColor: '#48bb78'
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: { legend: { display: false } },
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    ticks: { color: '#e2e8f0' }
+                },
+                x: {
+                    ticks: { color: '#e2e8f0' }
                 }
             }
         }
@@ -1144,8 +1232,63 @@ const renderOneKTimeChart = (records, statusElement) => {
     });
 };
 
+const renderChronologyTimeChart = (records, statusElement) => {
+    const canvas = document.getElementById('chronologyTimeChart');
+    if (!canvas) return;
+
+    const validTimes = records
+        .map(record => record.timeMinutes)
+        .filter(value => typeof value === 'number' && !Number.isNaN(value));
+
+    if (chronologyTimeChartInstance) {
+        chronologyTimeChartInstance.destroy();
+        chronologyTimeChartInstance = null;
+    }
+
+    if (!validTimes.length) {
+        if (statusElement) {
+            statusElement.textContent = 'Sin tiempos registrados para los filtros seleccionados.';
+            statusElement.classList.remove('hidden');
+        }
+        return;
+    }
+
+    if (statusElement) {
+        statusElement.textContent = '';
+        statusElement.classList.add('hidden');
+    }
+
+    const histogram = buildTimeHistogram(validTimes, 5);
+
+    chronologyTimeChartInstance = new Chart(canvas.getContext('2d'), {
+        type: 'bar',
+        data: {
+            labels: histogram.labels,
+            datasets: [{
+                label: 'Participantes',
+                data: histogram.counts,
+                backgroundColor: '#9f7aea'
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: { legend: { display: false } },
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    ticks: { color: '#e2e8f0' }
+                },
+                x: {
+                    ticks: { color: '#e2e8f0', maxRotation: 45, minRotation: 45 }
+                }
+            }
+        }
+    });
+};
+
 const renderYearTrendChart = (data) => {
-    const canvas = document.getElementById('yearTrendChart');
+    const canvas = document.getElementById('chronologyTrendChart');
     if (!canvas) return;
 
     if (yearTrendChartInstance) {
@@ -1197,23 +1340,14 @@ const createEmptyState = (message) => {
 };
 
 async function initializeChronology() {
-    const dashboard = document.getElementById('chronologyDashboard');
-    if (!dashboard) return;
+    const summaryElement = document.getElementById('summary-events');
+    if (!summaryElement) return;
 
     try {
-        const [
-            indexData,
-            events,
-            distances,
-            genders,
-            ageGroups,
-            rawResults
-        ] = await Promise.all([
-            fetchJson('./assets/data/index.json'),
+        const [events, distances, genders, rawResults] = await Promise.all([
             fetchJson('./assets/data/events.json'),
             fetchJson('./assets/data/distances.json'),
             fetchJson('./assets/data/genders.json'),
-            fetchJson('./assets/data/age_groups.json'),
             fetchJson('./assets/data/history_results.json')
         ]);
 
@@ -1221,102 +1355,77 @@ async function initializeChronology() {
             .map(normalizeRecordForStats)
             .filter(Boolean);
 
-        const uniqueParticipantsData = aggregateUniqueParticipantsByDistance(normalizedRecords);
-        renderDistanceParticipantsChart(uniqueParticipantsData);
-
-        const genderDistribution = aggregateGenderDistribution(normalizedRecords);
-        genderSummaryChartInstance = renderGenderSummaryChart(genderDistribution, 'genderSummaryChart', genderSummaryChartInstance);
-
+        const { femaleCount, maleCount, total } = summarizeGenderCounts(normalizedRecords);
         const totalUniqueParticipants = new Set(normalizedRecords.map(record => record.participantKey)).size;
-        setTextContent('chronology-participants-count', totalUniqueParticipants || '0');
 
-        const yearlyData = aggregateParticipantsByYear(normalizedRecords);
-        renderYearTrendChart(yearlyData);
+        setTextContent('summary-events', events.length || '0');
+        setTextContent('summary-participants', totalUniqueParticipants || '0');
+        setTextContent('summary-female', femaleCount || '0');
+        setTextContent('summary-male', maleCount || '0');
 
-        const oneKRecords = normalizedRecords.filter(record => record.distance === '1K');
-        const oneKParticipantsSet = new Set(oneKRecords.map(record => record.participantKey));
-        setTextContent('oneKParticipantsCount', oneKParticipantsSet.size || '0');
+        const oneKParticipants = new Set(normalizedRecords.filter(record => record.distance === '1K').map(record => record.participantKey)).size;
+        const fiveKParticipants = new Set(normalizedRecords.filter(record => record.distance === '5K').map(record => record.participantKey)).size;
+        setTextContent('summary-1k', oneKParticipants || '0');
+        setTextContent('summary-5k', fiveKParticipants || '0');
 
-        const oneKGenderDistribution = aggregateGenderDistribution(oneKRecords);
-        oneKGenderChartInstance = renderGenderSummaryChart(oneKGenderDistribution, 'oneKGenderChart', oneKGenderChartInstance);
+        renderChronologyAgeChart(normalizedRecords);
+        renderYearTrendChart(aggregateParticipantsByYear(normalizedRecords));
 
-        const oneKAgeDistribution = aggregateAgeDistribution(oneKRecords);
-        renderOneKAgeChart(oneKAgeDistribution);
+        const uniqueCategories = Array.from(new Set(normalizedRecords.map(record => record.category))).filter(Boolean).sort();
+        const eventOptions = events.map(event => {
+            const info = parseEventInfo(event.name);
+            return { value: buildEventKey(info, event.name), label: info.label };
+        });
 
-        const oneKGenderFilter = document.getElementById('oneKGenderFilter');
-        const oneKAgeFilter = document.getElementById('oneKAgeFilter');
-        const oneKTimeStatus = document.getElementById('oneKTimeStatus');
+        populateSelect('chronologyEventFilter', eventOptions, 'Todos', option => option.value, option => option.label);
+        populateSelect('chronologyGenderFilter', genders, 'Todos', gender => gender.raw, gender => gender.raw);
+        populateSelect('chronologyCategoryFilter', uniqueCategories, 'Todos', value => value, value => value);
+        populateSelect('chronologyDistanceFilter', distances, 'Todos', distance => distance.label, distance => `${distance.label} (${distance.km} km)`);
 
-        if (oneKRecords.length > 0) {
-            const genderOptions = Array.from(new Set(oneKRecords.map(record => record.gender))).filter(Boolean).sort();
-            populateSelect(
-                'oneKGenderFilter',
-                genderOptions.map(value => ({ value, label: value })),
-                'Todos los géneros',
-                option => option.value,
-                option => option.label
-            );
+        const eventSelect = document.getElementById('chronologyEventFilter');
+        const genderSelect = document.getElementById('chronologyGenderFilter');
+        const categorySelect = document.getElementById('chronologyCategoryFilter');
+        const distanceSelect = document.getElementById('chronologyDistanceFilter');
+        const applyButton = document.getElementById('applyChronologyFilters');
+        const timeStatus = document.getElementById('chronologyTimeStatus');
 
-            const ageOptions = Array.from(new Set(oneKRecords.map(record => record.ageGroup))).filter(Boolean).sort();
-            populateSelect(
-                'oneKAgeFilter',
-                ageOptions.map(value => ({ value, label: value })),
-                'Todas las edades',
-                option => option.value,
-                option => option.label
-            );
-        } else {
-            if (oneKGenderFilter) {
-                oneKGenderFilter.innerHTML = '<option value="">Sin datos disponibles</option>';
-                oneKGenderFilter.disabled = true;
-            }
-            if (oneKAgeFilter) {
-                oneKAgeFilter.innerHTML = '<option value="">Sin datos disponibles</option>';
-                oneKAgeFilter.disabled = true;
-            }
-        }
+        const applyFilters = () => {
+            const eventValue = eventSelect ? eventSelect.value : '';
+            const genderValue = genderSelect ? normalizeText(genderSelect.value) : '';
+            const categoryValue = categorySelect ? categorySelect.value : '';
+            const distanceValue = distanceSelect ? distanceSelect.value : '';
 
-        const applyOneKFilters = () => {
-            if (!oneKRecords.length) {
-                renderOneKTimeChart([], oneKTimeStatus);
-                return;
-            }
-
-            const genderValue = oneKGenderFilter ? normalizeText(oneKGenderFilter.value) : '';
-            const ageValue = oneKAgeFilter ? oneKAgeFilter.value : '';
-
-            const filtered = oneKRecords.filter(record => {
-                const genderMatches = !genderValue || normalizeText(record.gender) === genderValue;
-                const ageMatches = !ageValue || record.ageGroup === ageValue;
-                return genderMatches && ageMatches;
+            const filtered = normalizedRecords.filter(record => {
+                const matchesEvent = !eventValue || record.eventKey === eventValue;
+                const matchesGender = !genderValue || normalizeText(record.gender) === genderValue;
+                const matchesCategory = !categoryValue || record.category === categoryValue;
+                const matchesDistance = !distanceValue || record.distance === distanceValue;
+                return matchesEvent && matchesGender && matchesCategory && matchesDistance;
             });
 
-            renderOneKTimeChart(filtered, oneKTimeStatus);
+            const genderCounts = summarizeGenderCounts(filtered);
+            const uniqueParticipants = new Set(filtered.map(record => record.participantKey)).size;
+
+            setTextContent('filtered-participants', uniqueParticipants || '0');
+            setTextContent('filtered-female', genderCounts.femaleCount || '0');
+            setTextContent('filtered-male', genderCounts.maleCount || '0');
+
+            renderChronologyTimeChart(filtered, timeStatus);
         };
 
-        if (oneKGenderFilter) {
-            oneKGenderFilter.addEventListener('change', applyOneKFilters);
+        [eventSelect, genderSelect, categorySelect, distanceSelect].forEach(select => {
+            if (select) {
+                select.addEventListener('change', applyFilters);
+            }
+        });
+
+        if (applyButton) {
+            applyButton.addEventListener('click', applyFilters);
         }
 
-        if (oneKAgeFilter) {
-            oneKAgeFilter.addEventListener('change', applyOneKFilters);
-        }
-
-        applyOneKFilters();
-
-        populateSelect('edition', events, 'Selecciona un evento', event => event.name, event => event.name);
-        populateSelect('gender', genders, 'Selecciona un sexo', gender => gender.raw, gender => gender.raw);
-        populateSelect('category', distances, 'Selecciona una distancia', distance => distance.label, distance => `${distance.label} (${distance.km} km)`);
-
-        const counts = indexData?.counts || {};
-        setTextContent('chronology-events-count', counts.events || events.length);
-        setTextContent('chronology-distances-count', counts.distances || distances.length);
-        setTextContent('chronology-genders-count', counts.genders || genders.length);
-
-        renderAgeChart(ageGroups);
-        renderDistanceChart(normalizedRecords);
+        applyFilters();
     } catch (error) {
         console.error('Error al inicializar cronología:', error);
-        dashboard.insertAdjacentElement('beforebegin', createEmptyState('No se pudieron cargar los datos de cronología.'));
+        summaryElement.insertAdjacentElement('beforebegin', createEmptyState('No se pudieron cargar los datos de cronología.'));
     }
 }

--- a/cronologia.html
+++ b/cronologia.html
@@ -7,148 +7,120 @@
         </div>
     </header>
 
-    <div id="chronologyHighlights" class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <div class="card card-compact bg-gray-800 text-white rounded-lg shadow-md">
-            <h3 class="text-lg font-semibold text-green-400">Participantes únicos por distancia</h3>
-            <p class="text-sm text-gray-400 mt-1">Atletas distintos registrados en cada trayecto.</p>
-            <div class="chart-wrapper chart-wrapper-small mt-4">
-                <canvas id="distanceParticipantsChart" class="chart-canvas chart-canvas-small"></canvas>
-            </div>
-        </div>
-        <div class="card card-compact bg-gray-800 text-white rounded-lg shadow-md">
-            <h3 class="text-lg font-semibold text-green-400">Distribución por género</h3>
-            <p class="text-sm text-gray-400 mt-1">Balance general entre ramas femenil y varonil.</p>
-            <div class="chart-wrapper chart-wrapper-small mt-4">
-                <canvas id="genderSummaryChart" class="chart-canvas chart-canvas-small"></canvas>
-            </div>
-        </div>
-    </div>
-
-    <div id="yearTrendCard" class="card bg-gray-800 text-white p-6 rounded-lg shadow-md">
-        <h3 class="text-lg font-semibold text-green-400">Participantes únicos por año</h3>
-        <p class="text-sm text-gray-400 mt-1">Comparativo histórico del total de nadadores registrados en cada edición.</p>
-        <div class="chart-wrapper mt-4">
-            <canvas id="yearTrendChart" class="chart-canvas"></canvas>
-        </div>
-    </div>
-
-    <div id="chronologyFilters" class="bg-gray-800 p-6 rounded-lg shadow-md">
-        <h3 class="text-lg font-semibold text-green-400 mb-4">Filtros</h3>
+    <section aria-label="Resumen general" class="space-y-4">
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            <div>
-                <label for="edition" class="block text-sm font-medium text-white mb-1">Evento</label>
-                <select
-                    id="edition"
-                    class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400">
-                    <option value="">Cargando eventos...</option>
-                </select>
+            <div class="card bg-gray-800 text-white p-4 rounded-lg shadow-md">
+                <p class="text-sm text-gray-400">Eventos registrados</p>
+                <p id="summary-events" class="text-3xl font-bold text-green-500 mt-1">—</p>
             </div>
-            <div>
-                <label for="gender" class="block text-sm font-medium text-white mb-1">Sexo</label>
-                <select
-                    id="gender"
-                    class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400">
-                    <option value="">Cargando catálogos...</option>
-                </select>
+            <div class="card bg-gray-800 text-white p-4 rounded-lg shadow-md">
+                <p class="text-sm text-gray-400">Participantes únicos</p>
+                <p id="summary-participants" class="text-3xl font-bold text-green-500 mt-1">—</p>
             </div>
-            <div>
-                <label for="category" class="block text-sm font-medium text-white mb-1">Distancia</label>
-                <select
-                    id="category"
-                    class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400">
-                    <option value="">Cargando distancias...</option>
-                </select>
+            <div class="card bg-gray-800 text-white p-4 rounded-lg shadow-md">
+                <p class="text-sm text-gray-400">Mujeres</p>
+                <p id="summary-female" class="text-3xl font-bold text-green-500 mt-1">—</p>
+            </div>
+            <div class="card bg-gray-800 text-white p-4 rounded-lg shadow-md">
+                <p class="text-sm text-gray-400">Hombres</p>
+                <p id="summary-male" class="text-3xl font-bold text-green-500 mt-1">—</p>
+            </div>
+            <div class="card bg-gray-800 text-white p-4 rounded-lg shadow-md">
+                <p class="text-sm text-gray-400">Participantes en 1K</p>
+                <p id="summary-1k" class="text-3xl font-bold text-green-500 mt-1">—</p>
+            </div>
+            <div class="card bg-gray-800 text-white p-4 rounded-lg shadow-md">
+                <p class="text-sm text-gray-400">Participantes en 5K</p>
+                <p id="summary-5k" class="text-3xl font-bold text-green-500 mt-1">—</p>
             </div>
         </div>
-        <div class="mt-4 text-right">
-            <button
-                id="applyFilters"
-                class="bg-green-500 text-white px-4 py-2 rounded-lg hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-400">
-                Aplicar Filtros
-            </button>
-        </div>
-    </div>
 
-    <section id="oneKSection" class="space-y-6">
-        <div class="flex items-center justify-between flex-wrap gap-2">
-            <h3 class="text-2xl font-semibold text-green-400">Análisis de la distancia 1K</h3>
-            <p class="text-sm text-gray-400">Resumen dinámico por género, edad y tiempos.</p>
-        </div>
-        <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
-            <div class="card card-compact bg-gray-800 text-white rounded-lg shadow-md">
-                <h4 class="text-lg font-semibold text-green-400">Participantes 1K</h4>
-                <p id="oneKParticipantsCount" class="text-4xl font-bold mt-3">—</p>
-                <p class="text-sm text-gray-400 mt-2">Total de atletas distintos que han nadado 1K.</p>
-            </div>
-            <div class="card card-compact bg-gray-800 text-white rounded-lg shadow-md">
-                <h4 class="text-lg font-semibold text-green-400">Género (1K)</h4>
-                <div class="chart-wrapper chart-wrapper-small mt-3">
-                    <canvas id="oneKGenderChart" class="chart-canvas chart-canvas-small"></canvas>
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            <div class="card bg-gray-800 text-white p-4 rounded-lg shadow-md">
+                <div class="flex items-center justify-between">
+                    <h3 class="text-lg font-semibold text-green-400">Distribución por edad</h3>
+                    <span class="text-xs text-gray-400">General</span>
+                </div>
+                <div class="chart-wrapper mt-4">
+                    <canvas id="chronologyAgeChart" class="chart-canvas"></canvas>
                 </div>
             </div>
-            <div class="card card-compact bg-gray-800 text-white rounded-lg shadow-md">
-                <h4 class="text-lg font-semibold text-green-400">Edad (1K)</h4>
-                <div class="chart-wrapper chart-wrapper-small mt-3">
-                    <canvas id="oneKAgeChart" class="chart-canvas chart-canvas-small"></canvas>
+            <div class="card bg-gray-800 text-white p-4 rounded-lg shadow-md">
+                <div class="flex items-center justify-between">
+                    <h3 class="text-lg font-semibold text-green-400">Participantes por año</h3>
+                    <span class="text-xs text-gray-400">Serie histórica</span>
                 </div>
-            </div>
-        </div>
-        <div class="card bg-gray-800 text-white p-6 rounded-lg shadow-md">
-            <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-                <div>
-                    <h4 class="text-lg font-semibold text-green-400">Distribución de tiempos (1K)</h4>
-                    <p class="text-sm text-gray-400">Filtra por género y grupo de edad para actualizar el histograma.</p>
+                <div class="chart-wrapper mt-4">
+                    <canvas id="chronologyTrendChart" class="chart-canvas"></canvas>
                 </div>
-                <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 w-full md:w-auto">
-                    <div>
-                        <label for="oneKGenderFilter" class="block text-xs text-gray-400 uppercase tracking-wide">Género</label>
-                        <select id="oneKGenderFilter" class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400">
-                            <option value="">Todos los géneros</option>
-                        </select>
-                    </div>
-                    <div>
-                        <label for="oneKAgeFilter" class="block text-xs text-gray-400 uppercase tracking-wide">Grupo de edad</label>
-                        <select id="oneKAgeFilter" class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400">
-                            <option value="">Todas las edades</option>
-                        </select>
-                    </div>
-                </div>
-            </div>
-            <p id="oneKTimeStatus" class="text-sm text-gray-400 mt-3 hidden"></p>
-            <div class="chart-wrapper mt-4">
-                <canvas id="oneKTimeChart" class="chart-canvas"></canvas>
             </div>
         </div>
     </section>
 
-    <div id="chronologyDashboard" class="grid grid-cols-1 lg:grid-cols-4 gap-6">
-        <div class="card bg-gray-800 text-white p-6 rounded-lg shadow-md">
-            <h3 class="text-lg font-semibold text-green-400">Eventos registrados</h3>
-            <p id="chronology-events-count" class="text-3xl font-bold mt-2 text-green-500">—</p>
+    <section aria-label="Filtros de cronología" class="bg-gray-800 p-6 rounded-lg shadow-md space-y-4">
+        <div class="flex items-center justify-between flex-wrap gap-3">
+            <h3 class="text-lg font-semibold text-green-400">Filtrar resultados</h3>
+            <p class="text-sm text-gray-400">Selecciona evento, sexo, rama y distancia. Cada lista incluye la opción "Todos".</p>
         </div>
-        <div class="card bg-gray-800 text-white p-6 rounded-lg shadow-md lg:col-span-3 lg:row-span-2">
-            <h3 class="text-lg font-semibold text-green-400">Distribución por edad</h3>
-            <div class="chart-wrapper mt-4">
-                <canvas id="activityChart" class="chart-canvas"></canvas>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+            <div>
+                <label for="chronologyEventFilter" class="block text-sm font-medium text-white mb-1">Evento</label>
+                <select id="chronologyEventFilter" class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400">
+                    <option value="">Todos</option>
+                </select>
+            </div>
+            <div>
+                <label for="chronologyGenderFilter" class="block text-sm font-medium text-white mb-1">Sexo</label>
+                <select id="chronologyGenderFilter" class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400">
+                    <option value="">Todos</option>
+                </select>
+            </div>
+            <div>
+                <label for="chronologyCategoryFilter" class="block text-sm font-medium text-white mb-1">Rama</label>
+                <select id="chronologyCategoryFilter" class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400">
+                    <option value="">Todos</option>
+                </select>
+            </div>
+            <div>
+                <label for="chronologyDistanceFilter" class="block text-sm font-medium text-white mb-1">Distancia</label>
+                <select id="chronologyDistanceFilter" class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400">
+                    <option value="">Todos</option>
+                </select>
+            </div>
+        </div>
+        <div class="text-right">
+            <button id="applyChronologyFilters" class="bg-green-500 text-white px-4 py-2 rounded-lg hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-400">
+                Aplicar filtros
+            </button>
+        </div>
+    </section>
+
+    <section aria-label="Resultados filtrados" class="space-y-4">
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div class="card bg-gray-800 text-white p-4 rounded-lg shadow-md">
+                <p class="text-sm text-gray-400">Participantes filtrados</p>
+                <p id="filtered-participants" class="text-3xl font-bold text-green-500 mt-1">—</p>
+            </div>
+            <div class="card bg-gray-800 text-white p-4 rounded-lg shadow-md">
+                <p class="text-sm text-gray-400">Mujeres</p>
+                <p id="filtered-female" class="text-3xl font-bold text-green-500 mt-1">—</p>
+            </div>
+            <div class="card bg-gray-800 text-white p-4 rounded-lg shadow-md">
+                <p class="text-sm text-gray-400">Hombres</p>
+                <p id="filtered-male" class="text-3xl font-bold text-green-500 mt-1">—</p>
             </div>
         </div>
         <div class="card bg-gray-800 text-white p-6 rounded-lg shadow-md">
-            <h3 class="text-lg font-semibold text-green-400">Participaciones registradas</h3>
-            <p id="chronology-participants-count" class="text-3xl font-bold mt-2 text-green-500">—</p>
-        </div>
-        <div class="card bg-gray-800 text-white p-6 rounded-lg shadow-md">
-            <h3 class="text-lg font-semibold text-green-400">Distancias catalogadas</h3>
-            <p id="chronology-distances-count" class="text-3xl font-bold mt-2 text-green-500">—</p>
-        </div>
-        <div class="card bg-gray-800 text-white p-6 rounded-lg shadow-md">
-            <h3 class="text-lg font-semibold text-green-400">Géneros catalogados</h3>
-            <p id="chronology-genders-count" class="text-3xl font-bold mt-2 text-green-500">—</p>
-        </div>
-        <div class="card bg-gray-800 text-white p-6 rounded-lg shadow-md">
-            <h3 class="text-lg font-semibold text-green-400">Participantes por distancia</h3>
+            <div class="flex items-center justify-between flex-wrap gap-2">
+                <div>
+                    <h3 class="text-lg font-semibold text-green-400">Distribución de tiempos</h3>
+                    <p class="text-sm text-gray-400">Histograma de los tiempos registrados para los filtros actuales.</p>
+                </div>
+                <p id="chronologyTimeStatus" class="text-sm text-gray-400 hidden">—</p>
+            </div>
             <div class="chart-wrapper mt-4">
-                <canvas id="distanceChart" class="chart-canvas"></canvas>
+                <canvas id="chronologyTimeChart" class="chart-canvas"></canvas>
             </div>
         </div>
-    </div>
+    </section>
 </div>


### PR DESCRIPTION
## Summary
- add a stable event key derived from parsed event metadata to avoid conflicts when filtering chronology data
- align event filter options and record normalization to use the new key while preserving readable labels
- keep filtered time distribution and counts synced to the updated event matching

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693de39c7f04832c9db0a956e69edd42)