### PR TITLE
Refine cronología estadísticas y gráficos

### DIFF
--- a/cronologia.html
+++ b/cronologia.html
@@ -47,8 +47,8 @@
             </div>
             <div class="card bg-gray-800 text-white p-4 rounded-lg shadow-md">
                 <div class="flex items-center justify-between">
-                    <h3 class="text-lg font-semibold text-green-400">Participantes por año</h3>
-                    <span class="text-xs text-gray-400">Serie histórica</span>
+                    <h3 class="text-lg font-semibold text-green-400">Participantes por evento</h3>
+                    <span class="text-xs text-gray-400">Edición a edición</span>
                 </div>
                 <div class="chart-wrapper mt-4">
                     <canvas id="chronologyTrendChart" class="chart-canvas"></canvas>


### PR DESCRIPTION
## Summary
- Corrige el cálculo de claves de participantes para contar correctamente los únicos en los resúmenes y filtros
- Cambia la serie histórica a participantes por evento/edición y actualiza el copy en la tarjeta correspondiente
- Ajusta histogramas de tiempos para descartar registros fuera de rango por distancia y mostrar desglose por género

## Testing
- No automated tests were run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ee27f6fc0832cb0aaa53b141c8761)