### PR TITLE
Ajusta layout de inicio y mapa de procedencias

### DIFF
--- a/inicio.html
+++ b/inicio.html
@@ -7,6 +7,21 @@
                     <h1 class="text-4xl md:text-5xl font-bold">Maratón Internacional Acapulco</h1>
                     <p class="text-sm text-gray-300 max-w-xl">Un vistazo rápido al desempeño histórico del maratón: participantes, tendencias, tiempos y procedencia.</p>
                 </div>
+                <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mt-4">
+                    <div class="lg:col-span-1 bg-gray-900/40 border border-gray-700/60 rounded-lg p-4 space-y-2">
+                        <p class="text-sm text-gray-200 font-semibold">Evolución de participación</p>
+                        <p class="text-xs text-gray-300 leading-relaxed">Comparativa histórica de participantes únicos por evento para seguir el crecimiento del maratón.</p>
+                    </div>
+                    <div class="lg:col-span-2 bg-gray-900/40 border border-gray-700/60 rounded-lg p-4">
+                        <div class="flex items-center justify-between">
+                            <h3 class="text-lg font-semibold text-green-400">Participantes por evento</h3>
+                            <span class="text-xs text-gray-300">Edición a edición</span>
+                        </div>
+                        <div class="chart-wrapper mt-2 h-60">
+                            <canvas id="chronologyTrendChart" class="chart-canvas"></canvas>
+                        </div>
+                    </div>
+                </div>
             </div>
 
             <div class="grid grid-cols-2 lg:grid-cols-4 gap-3">
@@ -25,31 +40,6 @@
                 <div class="bg-gray-800 p-4 rounded-lg border border-gray-700 shadow-lg">
                     <p class="text-xs text-gray-400 uppercase">Participantes en 5K</p>
                     <p id="summary-5k" class="text-3xl font-bold text-green-400 mt-1">—</p>
-                </div>
-            </div>
-
-            <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
-                <div class="card bg-gray-800 text-white p-4 rounded-lg shadow-md border border-gray-700 lg:col-span-2">
-                    <div class="flex items-center justify-between">
-                        <h3 class="text-lg font-semibold text-green-400">Participantes por evento</h3>
-                        <span class="text-xs text-gray-400">Edición a edición</span>
-                    </div>
-                    <div class="chart-wrapper mt-2 h-60">
-                        <canvas id="chronologyTrendChart" class="chart-canvas"></canvas>
-                    </div>
-                </div>
-                <div class="bg-gray-800 text-white p-4 rounded-lg shadow-md border border-gray-700 flex flex-col gap-3">
-                    <div class="flex items-center justify-between">
-                        <h3 class="text-lg font-semibold text-green-400">Mapa de procedencias</h3>
-                        <span class="text-xs text-gray-400">Referencial</span>
-                    </div>
-                    <div class="overflow-hidden rounded-lg border border-gray-700 shadow-inner">
-                        <iframe id="stateMapEmbed" class="w-full h-64 map-iframe" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d30050.040800734227!2d-99.91836504953898!3d16.86146527569212!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x85ca5f1cf0c712ad%3A0x402a359351a8fc0!2sAcapulco%20de%20Ju%C3%A1rez%2C%20Gro.!5e0!3m2!1ses-419!2smx!4v1718150400000!5m2!1ses-419!2smx" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                    </div>
-                    <div>
-                        <p class="text-xs uppercase text-gray-400">Estados con más presencia</p>
-                        <ul id="stateTopList" class="text-sm text-gray-200 mt-1 space-y-1"></ul>
-                    </div>
                 </div>
             </div>
 
@@ -80,6 +70,22 @@
                             <span>Hombres</span>
                             <span id="summary-male" class="font-bold text-green-400">—</span>
                         </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="grid grid-cols-1">
+                <div class="bg-gray-800 text-white p-5 rounded-lg shadow-md border border-gray-700 flex flex-col gap-4">
+                    <div class="flex items-center justify-between">
+                        <h3 class="text-lg font-semibold text-green-400">Mapa de procedencias</h3>
+                        <span class="text-xs text-gray-400">Participantes únicos</span>
+                    </div>
+                    <div class="state-map-wrapper">
+                        <div id="stateMapGrid" class="state-grid"></div>
+                    </div>
+                    <div>
+                        <p class="text-xs uppercase text-gray-400">Estados con más presencia</p>
+                        <ul id="stateTopList" class="text-sm text-gray-200 mt-1 space-y-1"></ul>
                     </div>
                 </div>
             </div>
@@ -129,7 +135,7 @@
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
                     <div class="card bg-gray-800 text-white p-5 rounded-lg shadow-md border border-gray-700">
                         <div class="text-center">
-                            <h3 class="text-lg font-semibold text-green-400">Distribución de tiempos 1K</h3>
+                            <h3 class="text-lg font-semibold text-green-400">1K</h3>
                             <p id="chronologyTimeStatus1k" class="text-sm text-gray-400 hidden mt-1">—</p>
                         </div>
                         <div class="chart-wrapper mt-3 h-52">
@@ -138,7 +144,7 @@
                     </div>
                     <div class="card bg-gray-800 text-white p-5 rounded-lg shadow-md border border-gray-700">
                         <div class="text-center">
-                            <h3 class="text-lg font-semibold text-green-400">Distribución de tiempos 5K</h3>
+                            <h3 class="text-lg font-semibold text-green-400">5K</h3>
                             <p id="chronologyTimeStatus5k" class="text-sm text-gray-400 hidden mt-1">—</p>
                         </div>
                         <div class="chart-wrapper mt-3 h-52">


### PR DESCRIPTION
## Summary
- Moved the event participation trend into the hero card for quicker visibility and repositioned the provenance map after the age and gender breakdowns
- Replaced the Google Maps iframe with a Mexico tile map colored by participant volume while keeping the top-state list
- Simplified the time distribution card titles and limited the 1K histogram to times under 60 minutes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694294c97eec832ca6e541d411b98b81)