### PR TITLE
Simplify dashboard filters and layout

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -1822,8 +1822,6 @@ async function initializeChronology() {
             Hombres: genderSummary.maleCount
         });
 
-        renderStateMap(aggregateParticipantsByState(normalizedRecords));
-
         const oneKParticipants = new Set(normalizedRecords.filter(record => record.distance === '1K').map(record => record.participantKey)).size;
         const fiveKParticipants = new Set(normalizedRecords.filter(record => record.distance === '5K').map(record => record.participantKey)).size;
         setTextContent('summary-1k', oneKParticipants || '0');
@@ -1854,7 +1852,6 @@ async function initializeChronology() {
         const eventSelect = document.getElementById('chronologyEventFilter');
         const genderSelect = document.getElementById('chronologyGenderFilter');
         const categorySelect = document.getElementById('chronologyCategoryFilter');
-        const applyButton = document.getElementById('applyChronologyFilters');
         const timeStatus = document.getElementById('chronologyTimeStatus');
         const distanceToggleButtons = document.querySelectorAll('[data-distance-toggle]');
         const genderToggleButtons = document.querySelectorAll('[data-gender-toggle]');
@@ -1951,10 +1948,6 @@ async function initializeChronology() {
                 select.addEventListener('change', applyFilters);
             }
         });
-
-        if (applyButton) {
-            applyButton.addEventListener('click', applyFilters);
-        }
 
         applyFilters();
     } catch (error) {

--- a/inicio.html
+++ b/inicio.html
@@ -30,11 +30,17 @@
             </div>
 
             <div class="bg-gray-800 text-white p-5 rounded-lg shadow-sm border border-gray-700/70">
-                <div class="flex items-center justify-between flex-wrap gap-2">
-                    <h3 class="text-lg font-semibold text-green-400">Tendencia de participación</h3>
-                    <span class="text-xs text-gray-400">Participantes por evento</span>
+                <div class="flex items-center justify-between">
+                    <h3 class="text-lg font-semibold text-green-400">Distribución por sexo</h3>
+                    <span class="text-xs text-gray-400">Participantes únicos</span>
                 </div>
-                <div class="chart-wrapper mt-3 h-60">
+                <div class="chart-wrapper h-52 mt-2">
+                    <canvas id="genderSummaryChart" class="chart-canvas"></canvas>
+                </div>
+            </div>
+
+            <div class="bg-gray-800 text-white p-5 rounded-lg shadow-sm border border-gray-700/70">
+                <div class="chart-wrapper h-60">
                     <canvas id="chronologyTrendChart" class="chart-canvas"></canvas>
                 </div>
             </div>
@@ -49,33 +55,6 @@
                 </div>
             </div>
 
-            <div class="grid grid-cols-1 gap-5 lg:grid-cols-2">
-                <div class="bg-gray-800 text-white p-5 rounded-lg shadow-sm border border-gray-700/70">
-                    <div class="flex items-center justify-between">
-                        <h3 class="text-lg font-semibold text-green-400">Distribución por sexo</h3>
-                        <span class="text-xs text-gray-400">Participantes únicos</span>
-                    </div>
-                    <div class="chart-wrapper h-52 mt-2">
-                        <canvas id="genderSummaryChart" class="chart-canvas"></canvas>
-                    </div>
-                </div>
-
-                <div class="bg-gray-800 text-white p-5 rounded-lg shadow-sm border border-gray-700/70 flex flex-col gap-4">
-                    <div class="flex items-center justify-between">
-                        <h3 class="text-lg font-semibold text-green-400">Mapa de procedencias</h3>
-                        <span class="text-xs text-gray-400">Participantes únicos</span>
-                    </div>
-                    <div class="flex flex-col lg:flex-row gap-4">
-                        <div class="state-map-wrapper flex-1">
-                            <div id="stateMapGrid" class="state-grid"></div>
-                        </div>
-                        <div class="lg:w-1/3 bg-gray-900/60 border border-gray-700/60 rounded-lg p-4 space-y-2">
-                            <p class="text-xs uppercase text-gray-400">Top 5 estados</p>
-                            <ul id="stateTopList" class="text-sm text-gray-200 space-y-1"></ul>
-                        </div>
-                    </div>
-                </div>
-            </div>
         </div>
 
         <aside class="xl:col-span-4 space-y-4 xl:sticky xl:top-6">
@@ -101,9 +80,6 @@
                         </div>
                     </div>
                     <div class="flex items-center justify-between gap-2 flex-wrap text-xs text-gray-300" id="activeFiltersSummary"></div>
-                    <div class="flex justify-end">
-                        <button id="applyChronologyFilters" class="bg-green-500 text-white px-4 py-2 rounded-lg hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-400 text-sm">Aplicar filtros</button>
-                    </div>
                 </div>
             </details>
 


### PR DESCRIPTION
## Summary
- Move the gender distribution chart to the top near the unique participants summary and remove the origin map section.
- Simplify the participation trend card by removing its title area.
- Remove the manual filter apply button so filters update automatically on change.

## Testing
- Not run (not provided).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69431c9393f0832c8e44a2c676ebeeee)