### PR TITLE
Enable participant deep links from chronology

### DIFF
--- a/inicio.html
+++ b/inicio.html
@@ -112,6 +112,17 @@
                         <canvas id="chronologyTimeChart" class="chart-canvas"></canvas>
                     </div>
                 </div>
+
+                <div class="bg-gray-900/60 rounded-lg border border-gray-700/60 p-4 space-y-3">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <p class="text-xs uppercase tracking-wide text-green-400">Participantes filtrados</p>
+                            <p class="text-sm text-gray-400">Haz clic en un nombre para abrir su historial.</p>
+                        </div>
+                        <span id="chronologyParticipantsCount" class="text-lg font-semibold text-green-400">—</span>
+                    </div>
+                    <div id="chronologyParticipantsList" class="flex flex-wrap gap-2 text-sm"></div>
+                </div>
             </section>
         </aside>
     </section>


### PR DESCRIPTION
## Summary
- add filtered participant chips in the chronology sidebar that link to detailed history
- expose navigation helper so clicking a participant loads the results view and opens their detail automatically

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944214b7dc8832ca1e76dfb70fd81d9)