### PR TITLE
Adjust dashboard layout and honor board participant chips

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -2066,6 +2066,17 @@ async function initializeHonorBoard() {
     const nextButton = document.getElementById('honorBoardNext');
     const slideInfo = document.getElementById('honorBoardSlideInfo');
 
+    tableBody.addEventListener('click', (event) => {
+        const chip = event.target.closest('[data-participant-key]');
+        if (!chip) return;
+
+        const key = chip.getAttribute('data-participant-key');
+        const name = chip.getAttribute('data-participant-name') || chip.textContent;
+        if (key) {
+            navigateToResultsDetail(key, name);
+        }
+    });
+
     tableBody.innerHTML = '<tr><td colspan="9" class="py-4 px-2 text-center text-gray-400">Calculando medallero...</td></tr>';
 
     try {
@@ -2126,8 +2137,17 @@ async function initializeHonorBoard() {
                     <tr class="border-b border-gray-800 ${highlight}">
                         <td class="py-3 px-2 text-sm text-gray-400">${position}</td>
                         <td class="py-3 px-2">
-                            <div class="font-semibold text-white">${athlete.name}</div>
-                            <p class="text-xs text-gray-400">${athlete.origin || 'Procedencia no registrada'}</p>
+                            <div class="space-y-1">
+                                <button
+                                    type="button"
+                                    class="px-3 py-2 rounded-full bg-gray-800 border border-gray-700 hover:border-green-400 transition text-white"
+                                    data-participant-key="${athlete.key}"
+                                    data-participant-name="${athlete.name}"
+                                >
+                                    ${athlete.name}
+                                </button>
+                                <p class="text-xs text-gray-400">${athlete.origin || 'Procedencia no registrada'}</p>
+                            </div>
                         </td>
                         <td class="py-3 px-2 text-center text-yellow-300 font-semibold">${formatNumber(gold)}</td>
                         <td class="py-3 px-2 text-center text-gray-200">${formatNumber(silver)}</td>

--- a/inicio.html
+++ b/inicio.html
@@ -9,7 +9,7 @@
                         <p class="text-sm text-gray-200">Datos históricos en un vistazo.</p>
                     </div>
                 </div>
-                <div class="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-3 mt-5">
+                <div class="grid grid-cols-2 gap-3 mt-5">
                     <div class="bg-gray-900/60 p-4 rounded-lg border border-gray-700/60">
                         <p class="text-xs text-gray-400 uppercase">Eventos</p>
                         <p id="summary-events" class="text-3xl font-extrabold text-green-400 mt-1">—</p>
@@ -37,10 +37,28 @@
                 </div>
             </div>
 
-            <div class="grid gap-6 lg:grid-cols-2">
+            <div class="space-y-6">
                 <div class="bg-gray-800 text-white p-5 rounded-lg shadow-sm border border-gray-700/70">
                     <div class="chart-wrapper h-60">
                         <canvas id="chronologyTrendChart" class="chart-canvas"></canvas>
+                    </div>
+                </div>
+
+                <div class="bg-gray-800 text-white p-5 rounded-lg shadow-sm border border-gray-700/70 space-y-3">
+                    <div class="flex items-center justify-between flex-wrap gap-2">
+                        <div class="flex gap-2" role="group" aria-label="Seleccionar distancia">
+                            <button type="button" data-distance-toggle="1K" class="filter-toggle active">1K</button>
+                            <button type="button" data-distance-toggle="5K" class="filter-toggle">5K</button>
+                        </div>
+                        <div class="flex gap-2" role="group" aria-label="Seleccionar género">
+                            <button type="button" data-gender-toggle="combined" class="filter-toggle active">Combinado</button>
+                            <button type="button" data-gender-toggle="female" class="filter-toggle">Mujeres</button>
+                            <button type="button" data-gender-toggle="male" class="filter-toggle">Hombres</button>
+                        </div>
+                    </div>
+                    <p id="chronologyTimeStatus" class="text-sm text-gray-400 hidden">—</p>
+                    <div class="chart-wrapper h-52">
+                        <canvas id="chronologyTimeChart" class="chart-canvas"></canvas>
                     </div>
                 </div>
 
@@ -78,52 +96,6 @@
                     <div class="flex items-center justify-between gap-2 flex-wrap text-xs text-gray-300" id="activeFiltersSummary"></div>
                 </div>
             </details>
-
-            <section aria-label="Resultados filtrados" class="bg-gray-800 p-5 rounded-lg shadow-sm border border-gray-700/70 space-y-4">
-                <div class="grid grid-cols-3 gap-3 text-center">
-                    <div class="bg-gray-900/60 rounded-lg p-4 border border-gray-700/60">
-                        <p class="text-xs text-gray-400 uppercase">Participantes</p>
-                        <p id="filtered-participants" class="text-2xl font-bold text-green-500 mt-1">—</p>
-                    </div>
-                    <div class="bg-gray-900/60 rounded-lg p-4 border border-gray-700/60">
-                        <p class="text-xs text-gray-400 uppercase">Mujeres</p>
-                        <p id="filtered-female" class="text-2xl font-bold text-green-500 mt-1">—</p>
-                    </div>
-                    <div class="bg-gray-900/60 rounded-lg p-4 border border-gray-700/60">
-                        <p class="text-xs text-gray-400 uppercase">Hombres</p>
-                        <p id="filtered-male" class="text-2xl font-bold text-green-500 mt-1">—</p>
-                    </div>
-                </div>
-
-                <div class="bg-gray-900/60 rounded-lg border border-gray-700/60 p-4 space-y-3">
-                    <div class="flex items-center justify-between flex-wrap gap-2">
-                        <div class="flex gap-2" role="group" aria-label="Seleccionar distancia">
-                            <button type="button" data-distance-toggle="1K" class="filter-toggle active">1K</button>
-                            <button type="button" data-distance-toggle="5K" class="filter-toggle">5K</button>
-                        </div>
-                        <div class="flex gap-2" role="group" aria-label="Seleccionar género">
-                            <button type="button" data-gender-toggle="combined" class="filter-toggle active">Combinado</button>
-                            <button type="button" data-gender-toggle="female" class="filter-toggle">Mujeres</button>
-                            <button type="button" data-gender-toggle="male" class="filter-toggle">Hombres</button>
-                        </div>
-                    </div>
-                    <p id="chronologyTimeStatus" class="text-sm text-gray-400 hidden">—</p>
-                    <div class="chart-wrapper h-52">
-                        <canvas id="chronologyTimeChart" class="chart-canvas"></canvas>
-                    </div>
-                </div>
-
-                <div class="bg-gray-900/60 rounded-lg border border-gray-700/60 p-4 space-y-3">
-                    <div class="flex items-center justify-between">
-                        <div>
-                            <p class="text-xs uppercase tracking-wide text-green-400">Participantes filtrados</p>
-                            <p class="text-sm text-gray-400">Haz clic en un nombre para abrir su historial.</p>
-                        </div>
-                        <span id="chronologyParticipantsCount" class="text-lg font-semibold text-green-400">—</span>
-                    </div>
-                    <div id="chronologyParticipantsList" class="flex flex-wrap gap-2 text-sm"></div>
-                </div>
-            </section>
         </aside>
     </section>
 </div>


### PR DESCRIPTION
## Summary
- Stack dashboard summary cards in a 2x2x2 grid and relocate charts to show time first then age distribution
- Remove the filtered participants panel from Inicio while keeping filters available
- Render honor board names as interactive chips that link to participant history

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69446b6be8f8832ca8478a1b771b0679)