### PR TITLE
Reordena la página de inicio y añade opción de todos en filtros de eventos

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -1895,7 +1895,7 @@ async function initializeChronology() {
             return a.label.localeCompare(b.label);
         });
 
-        populateSelect('chronologyEventFilter', eventOptions, null, option => option.value, option => option.label);
+        populateSelect('chronologyEventFilter', eventOptions, 'Todos', option => option.value, option => option.label);
         populateSelect('chronologyGenderFilter', genders, 'Todos', gender => gender.raw, gender => gender.raw);
         populateSelect('chronologyCategoryFilter', uniqueCategories, 'Todos', value => value, value => value);
 
@@ -1966,12 +1966,6 @@ async function initializeChronology() {
                 ? chips.join('')
                 : '<span class="text-gray-400">Sin filtros aplicados</span>';
         };
-
-        const preferredEvent = eventOptions.find(option => option.edition === 66 && option.year === 2025) || eventOptions[0];
-
-        if (eventSelect && preferredEvent) {
-            eventSelect.value = preferredEvent.value;
-        }
 
         const renderFilteredTimeChart = () => {
             renderChronologyTimeChartForDistance(lastFilteredRecords, activeDistance, timeStatus, activeGenderView);

--- a/inicio.html
+++ b/inicio.html
@@ -1,101 +1,115 @@
 <div class="container mx-auto space-y-6">
-    <section class="grid gap-6 xl:grid-cols-12 items-start pt-6">
-        <div class="xl:col-span-7 space-y-6">
-            <div class="bg-gradient-to-r from-gray-800 to-gray-700 p-6 rounded-xl border border-gray-700/70 shadow-md">
-                <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-                    <div>
-                        <p class="text-xs font-semibold uppercase tracking-wide text-green-400">Dashboard</p>
-                        <h1 class="text-4xl md:text-5xl font-bold">Maratón Internacional Acapulco</h1>
-                        <p class="text-sm text-gray-200">Datos históricos en un vistazo.</p>
-                    </div>
+    <section class="space-y-6 pt-6">
+        <div class="grid gap-6 xl:grid-cols-12 items-start">
+            <div class="xl:col-span-5 bg-gradient-to-r from-gray-800 to-gray-700 p-6 rounded-xl border border-gray-700/70 shadow-md space-y-4">
+                <div class="space-y-2">
+                    <p class="text-xs font-semibold uppercase tracking-wide text-green-400">Dashboard</p>
+                    <h1 class="text-4xl md:text-5xl font-bold">Maratón Internacional Acapulco</h1>
+                    <p class="text-sm text-gray-200">Participantes únicos en un vistazo general.</p>
                 </div>
-                <div class="grid grid-cols-2 gap-3 mt-5">
-                    <div class="bg-gray-900/60 p-4 rounded-lg border border-gray-700/60">
-                        <p class="text-xs text-gray-400 uppercase">Eventos</p>
-                        <p id="summary-events" class="text-3xl font-extrabold text-green-400 mt-1">—</p>
-                    </div>
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
                     <div class="bg-green-600 p-4 rounded-lg text-gray-900">
                         <p class="text-xs text-gray-900/80 uppercase">Participantes únicos</p>
-                        <p id="summary-participants" class="text-3xl font-extrabold mt-1">—</p>
+                        <p id="summary-participants" class="text-4xl font-extrabold mt-1">—</p>
                     </div>
                     <div class="bg-gray-900/60 p-4 rounded-lg border border-gray-700/60">
-                        <p class="text-xs text-gray-400 uppercase">1K</p>
-                        <p id="summary-1k" class="text-3xl font-bold text-green-400 mt-1">—</p>
-                    </div>
-                    <div class="bg-gray-900/60 p-4 rounded-lg border border-gray-700/60">
-                        <p class="text-xs text-gray-400 uppercase">5K</p>
-                        <p id="summary-5k" class="text-3xl font-bold text-green-400 mt-1">—</p>
-                    </div>
-                    <div class="bg-gray-900/60 p-4 rounded-lg border border-gray-700/60">
-                        <p class="text-xs text-gray-400 uppercase">Mujeres</p>
-                        <p id="summary-female" class="text-3xl font-bold text-green-400 mt-1">—</p>
-                    </div>
-                    <div class="bg-gray-900/60 p-4 rounded-lg border border-gray-700/60">
-                        <p class="text-xs text-gray-400 uppercase">Hombres</p>
-                        <p id="summary-male" class="text-3xl font-bold text-green-400 mt-1">—</p>
+                        <p class="text-xs text-gray-400 uppercase">Eventos analizados</p>
+                        <p id="summary-events" class="text-3xl font-extrabold text-green-400 mt-1">—</p>
                     </div>
                 </div>
             </div>
 
-            <div class="space-y-6">
-                <div class="bg-gray-800 text-white p-5 rounded-lg shadow-sm border border-gray-700/70">
-                    <div class="chart-wrapper h-60">
-                        <canvas id="chronologyTrendChart" class="chart-canvas"></canvas>
+            <div class="xl:col-span-7 bg-gray-800 text-white p-5 rounded-lg shadow-sm border border-gray-700/70 space-y-3">
+                <div class="flex items-center justify-between flex-wrap gap-2">
+                    <div>
+                        <p class="text-sm text-green-400 font-semibold uppercase">Serie histórica</p>
+                        <h2 class="text-xl font-bold">Participantes únicos por evento</h2>
                     </div>
                 </div>
-
-                <div class="bg-gray-800 text-white p-5 rounded-lg shadow-sm border border-gray-700/70 space-y-3">
-                    <div class="flex items-center justify-between flex-wrap gap-2">
-                        <div class="flex gap-2" role="group" aria-label="Seleccionar distancia">
-                            <button type="button" data-distance-toggle="1K" class="filter-toggle active">1K</button>
-                            <button type="button" data-distance-toggle="5K" class="filter-toggle">5K</button>
-                        </div>
-                        <div class="flex gap-2" role="group" aria-label="Seleccionar género">
-                            <button type="button" data-gender-toggle="combined" class="filter-toggle active">Combinado</button>
-                            <button type="button" data-gender-toggle="female" class="filter-toggle">Mujeres</button>
-                            <button type="button" data-gender-toggle="male" class="filter-toggle">Hombres</button>
-                        </div>
-                    </div>
-                    <p id="chronologyTimeStatus" class="text-sm text-gray-400 hidden">—</p>
-                    <div class="chart-wrapper h-52">
-                        <canvas id="chronologyTimeChart" class="chart-canvas"></canvas>
-                    </div>
-                </div>
-
-                <div class="bg-gray-800 text-white p-5 rounded-lg shadow-sm border border-gray-700/70">
-                    <div class="chart-wrapper h-64">
-                        <canvas id="chronologyAgeChart" class="chart-canvas"></canvas>
-                    </div>
+                <div class="chart-wrapper h-64">
+                    <canvas id="chronologyTrendChart" class="chart-canvas"></canvas>
                 </div>
             </div>
-
         </div>
 
-        <aside class="xl:col-span-5 space-y-4 xl:sticky xl:top-6">
-            <details open class="bg-gray-800 p-5 rounded-lg shadow-sm border border-gray-700/70">
-                <summary class="text-lg font-semibold text-green-400 cursor-pointer">Filtros</summary>
-                <div class="mt-4 space-y-4">
-                    <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-                        <div>
-                            <label for="chronologyEventFilter" class="block text-sm font-medium text-white mb-1">Evento</label>
-                            <select id="chronologyEventFilter" class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400"></select>
-                        </div>
-                        <div>
-                            <label for="chronologyGenderFilter" class="block text-sm font-medium text-white mb-1">Sexo</label>
-                            <select id="chronologyGenderFilter" class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400">
-                                <option value="">Todos</option>
-                            </select>
-                        </div>
-                        <div class="md:col-span-2">
-                            <label for="chronologyCategoryFilter" class="block text-sm font-medium text-white mb-1">Categoría de edad</label>
-                            <select id="chronologyCategoryFilter" class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400">
-                                <option value="">Todas</option>
-                            </select>
-                        </div>
-                    </div>
-                    <div class="flex items-center justify-between gap-2 flex-wrap text-xs text-gray-300" id="activeFiltersSummary"></div>
+        <div class="bg-gray-800 p-5 rounded-lg shadow-sm border border-gray-700/70 space-y-4">
+            <div class="flex items-center justify-between gap-3 flex-wrap">
+                <div>
+                    <p class="text-xs uppercase text-green-400 font-semibold">Filtros</p>
+                    <h2 class="text-xl font-bold text-white">Refina la vista de participantes</h2>
                 </div>
-            </details>
-        </aside>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                <div>
+                    <label for="chronologyEventFilter" class="block text-sm font-medium text-white mb-1">Evento</label>
+                    <select id="chronologyEventFilter" class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400"></select>
+                </div>
+                <div>
+                    <label for="chronologyGenderFilter" class="block text-sm font-medium text-white mb-1">Sexo</label>
+                    <select id="chronologyGenderFilter" class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400">
+                        <option value="">Todos</option>
+                    </select>
+                </div>
+                <div>
+                    <label for="chronologyCategoryFilter" class="block text-sm font-medium text-white mb-1">Categoría de edad</label>
+                    <select id="chronologyCategoryFilter" class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400">
+                        <option value="">Todas</option>
+                    </select>
+                </div>
+            </div>
+            <div class="flex items-center justify-between gap-2 flex-wrap text-xs text-gray-300" id="activeFiltersSummary"></div>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div class="bg-gray-800 p-4 rounded-lg border border-gray-700/70">
+                <p class="text-xs text-gray-400 uppercase">Mujeres únicas</p>
+                <p id="summary-female" class="text-3xl font-bold text-green-400 mt-1">—</p>
+            </div>
+            <div class="bg-gray-800 p-4 rounded-lg border border-gray-700/70">
+                <p class="text-xs text-gray-400 uppercase">Hombres únicos</p>
+                <p id="summary-male" class="text-3xl font-bold text-green-400 mt-1">—</p>
+            </div>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div class="bg-gray-800 p-4 rounded-lg border border-gray-700/70">
+                <p class="text-xs text-gray-400 uppercase">Participantes 1K</p>
+                <p id="summary-1k" class="text-3xl font-bold text-green-400 mt-1">—</p>
+            </div>
+            <div class="bg-gray-800 p-4 rounded-lg border border-gray-700/70">
+                <p class="text-xs text-gray-400 uppercase">Participantes 5K</p>
+                <p id="summary-5k" class="text-3xl font-bold text-green-400 mt-1">—</p>
+            </div>
+        </div>
+
+        <div class="bg-gray-800 text-white p-5 rounded-lg shadow-sm border border-gray-700/70">
+            <div class="flex items-center justify-between mb-3">
+                <div>
+                    <p class="text-sm text-green-400 font-semibold uppercase">Distribución</p>
+                    <h2 class="text-xl font-bold">Edades de participantes únicos</h2>
+                </div>
+            </div>
+            <div class="chart-wrapper h-64">
+                <canvas id="chronologyAgeChart" class="chart-canvas"></canvas>
+            </div>
+        </div>
+
+        <div class="bg-gray-800 text-white p-5 rounded-lg shadow-sm border border-gray-700/70 space-y-3">
+            <div class="flex items-center justify-between flex-wrap gap-2">
+                <div class="flex gap-2" role="group" aria-label="Seleccionar distancia">
+                    <button type="button" data-distance-toggle="1K" class="filter-toggle active">1K</button>
+                    <button type="button" data-distance-toggle="5K" class="filter-toggle">5K</button>
+                </div>
+                <div class="flex gap-2" role="group" aria-label="Seleccionar género">
+                    <button type="button" data-gender-toggle="combined" class="filter-toggle active">Combinado</button>
+                    <button type="button" data-gender-toggle="female" class="filter-toggle">Mujeres</button>
+                    <button type="button" data-gender-toggle="male" class="filter-toggle">Hombres</button>
+                </div>
+            </div>
+            <p id="chronologyTimeStatus" class="text-sm text-gray-400 hidden">—</p>
+            <div class="chart-wrapper h-52">
+                <canvas id="chronologyTimeChart" class="chart-canvas"></canvas>
+            </div>
+        </div>
     </section>
 </div>


### PR DESCRIPTION
## Summary
- Reordena la página de inicio para mostrar primero el bloque principal con participantes únicos y la serie histórica.
- Coloca los filtros inmediatamente después con tarjetas de género y distancia en el orden solicitado, dejando edad y tiempos al final.
- Agrega la opción "Todos" al filtro de evento para permitir vistas sin restringir por competencia.

## Testing
- Manual verification in browser


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69455b50b6f4832c8c3ad02b7bb79e4a)