### PR TITLE
Rediseña el tablero de inicio

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2,8 +2,9 @@ html, body {
     margin: 0;
     padding: 0;
     font-family: 'Roboto', sans-serif;
-    background-color: #1a202c; /* bg-gray-900 */
+    background: radial-gradient(circle at 20% 20%, #1f2937 0, #0e1729 35%, #0b1321 65%, #0a0f1a 100%);
     scroll-behavior: smooth;
+    color: #e2e8f0;
 }
 
 .main-nav {
@@ -65,8 +66,6 @@ nav a.active::after {
 .content {
     padding: 0; /* El padding se manejará en las secciones internas */
 }
-
-
 
 footer {
     background: #1a202c; /* Coincide con bg-gray-900 */
@@ -382,4 +381,274 @@ footer {
 
 .chart-canvas-small {
     max-height: 200px;
+}
+
+/* ==========================
+   Dashboard de inicio
+   ========================== */
+
+.dashboard-shell {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 1.5rem;
+}
+
+.dashboard-grid {
+    display: grid;
+    grid-template-columns: 1.7fr 1fr;
+    gap: 1rem;
+}
+
+.panel {
+    background: linear-gradient(135deg, rgba(30, 41, 59, 0.85), rgba(17, 24, 39, 0.8));
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    border-radius: 18px;
+    padding: 1.25rem;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+    backdrop-filter: blur(6px);
+}
+
+.panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.75rem;
+}
+
+.panel-title {
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: #e5e7eb;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.muted {
+    color: #9ca3af;
+    font-size: 0.9rem;
+}
+
+.eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.7rem;
+    color: #34d399;
+    font-weight: 700;
+}
+
+.badge-soft {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    background: rgba(52, 211, 153, 0.12);
+    color: #a7f3d0;
+    border: 1px solid rgba(52, 211, 153, 0.25);
+    border-radius: 999px;
+    padding: 0.35rem 0.75rem;
+    font-weight: 700;
+    font-size: 0.75rem;
+}
+
+.hero-card {
+    position: relative;
+    overflow: hidden;
+}
+
+.hero-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 70% 20%, rgba(52, 211, 153, 0.18), transparent 40%);
+    pointer-events: none;
+}
+
+.stat-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0.75rem;
+    margin-top: 1rem;
+}
+
+.stat-card {
+    background: rgba(15, 23, 42, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 14px;
+    padding: 1rem;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.stat-card.highlight {
+    background: linear-gradient(145deg, #16a34a, #34d399);
+    color: #0f172a;
+    border-color: rgba(15, 23, 42, 0.2);
+    box-shadow: 0 10px 25px rgba(52, 211, 153, 0.25);
+}
+
+.stat-card.highlight .muted {
+    color: #0f172a;
+}
+
+.stat-label {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #9ca3af;
+}
+
+.stat-value {
+    font-size: 2.2rem;
+    font-weight: 800;
+    line-height: 1.1;
+    color: #e5e7eb;
+}
+
+.stat-value.large {
+    font-size: 2.6rem;
+}
+
+.stat-compare {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    background: rgba(52, 211, 153, 0.16);
+    color: #bbf7d0;
+    padding: 0.25rem 0.65rem;
+    border-radius: 999px;
+    font-weight: 700;
+    font-size: 0.85rem;
+    border: 1px solid rgba(52, 211, 153, 0.25);
+}
+
+.stat-compare.negative {
+    background: rgba(248, 113, 113, 0.18);
+    color: #fecdd3;
+    border-color: rgba(248, 113, 113, 0.35);
+}
+
+.stat-split {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+}
+
+.stat-mini {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.stat-mini span:first-child {
+    font-weight: 700;
+    color: #e5e7eb;
+}
+
+.chart-area {
+    position: relative;
+    height: 320px;
+}
+
+.chart-callout {
+    position: absolute;
+    right: 1rem;
+    top: 50%;
+    transform: translateY(-50%);
+    background: rgba(15, 23, 42, 0.9);
+    border: 1px solid rgba(52, 211, 153, 0.4);
+    padding: 0.85rem 1rem;
+    border-radius: 12px;
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.35);
+    min-width: 170px;
+}
+
+.chart-callout .callout-value {
+    font-size: 1.2rem;
+    font-weight: 800;
+    color: #a7f3d0;
+}
+
+.chart-callout .callout-label {
+    font-size: 0.85rem;
+    color: #9ca3af;
+}
+
+.filter-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 0.75rem;
+}
+
+.pill-button {
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.05);
+    color: #e2e8f0;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 0.55rem 1rem;
+    font-weight: 700;
+    cursor: pointer;
+    transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.pill-button:hover {
+    border-color: #34d399;
+}
+
+.stat-band {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+}
+
+.stat-pill {
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.07);
+    border-radius: 14px;
+    padding: 0.75rem;
+}
+
+.chip-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 0.5rem;
+}
+
+.participant-chip {
+    padding: 0.65rem 0.75rem;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    color: #e5e7eb;
+    cursor: pointer;
+    transition: border-color 0.2s ease, transform 0.1s ease;
+}
+
+.participant-chip:hover {
+    border-color: #34d399;
+    transform: translateY(-1px);
+}
+
+.chart-canvas-compact {
+    height: 240px !important;
+}
+
+.chart-wrapper.chart-canvas-compact {
+    height: 260px;
+}
+
+@media (max-width: 1200px) {
+    .dashboard-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 640px) {
+    .dashboard-shell {
+        padding: 1rem;
+    }
+
+    .panel {
+        padding: 1rem;
+    }
 }

--- a/inicio.html
+++ b/inicio.html
@@ -1,99 +1,168 @@
-<div class="container mx-auto space-y-4">
-    <section class="grid lg:grid-cols-2 gap-4 pt-4 items-start">
+<div class="dashboard-shell space-y-4">
+    <section class="dashboard-grid pt-4 items-start">
         <div class="space-y-4">
-            <div class="bg-gradient-to-r from-gray-800 to-gray-700 p-4 rounded-xl border border-gray-700/70 shadow-md space-y-3">
-                <div class="space-y-1">
-                    <p class="text-[10px] font-semibold uppercase tracking-wide text-green-400">Dashboard</p>
-                    <h1 class="text-3xl md:text-4xl font-bold leading-tight">Maratón Internacional Acapulco</h1>
-                    <p class="text-xs text-gray-200">Participantes únicos en un vistazo general.</p>
-                </div>
-                <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                    <div class="bg-green-600 p-3 rounded-lg text-gray-900">
-                        <p class="text-[10px] text-gray-900/80 uppercase">Participantes únicos</p>
-                        <p id="summary-participants" class="text-3xl font-extrabold mt-1 leading-tight">—</p>
+            <div class="panel hero-card">
+                <div class="panel-header">
+                    <div class="space-y-1">
+                        <p class="eyebrow">Dashboard</p>
+                        <h1 class="text-3xl md:text-4xl font-extrabold leading-tight text-white">Maratón Internacional Acapulco</h1>
+                        <p class="muted text-sm">Participantes únicos en un vistazo general.</p>
                     </div>
-                    <div class="bg-gray-900/60 p-3 rounded-lg border border-gray-700/60">
-                        <p class="text-[10px] text-gray-400 uppercase">Eventos analizados</p>
-                        <p id="summary-events" class="text-2xl font-extrabold text-green-400 mt-1 leading-tight">—</p>
+                    <div class="badge-soft">
+                        <span class="text-xs uppercase tracking-wide">Eventos analizados</span>
+                        <span id="summary-events" class="text-lg font-extrabold">—</span>
+                    </div>
+                </div>
+                <div class="stat-grid">
+                    <div class="stat-card highlight space-y-1">
+                        <p class="stat-label">Participantes únicos</p>
+                        <p id="summary-participants" class="stat-value large">—</p>
+                        <p class="muted text-xs">Sin duplicados por edición.</p>
+                    </div>
+                    <div class="stat-card space-y-1">
+                        <p class="stat-label">Variación último evento</p>
+                        <div class="flex items-center gap-2">
+                            <p id="summary-growth-count" class="stat-value text-green-300">—</p>
+                            <span id="summary-growth-percent" class="stat-compare">—</span>
+                        </div>
+                        <p id="summary-growth-context" class="muted text-xs">En comparación con el evento previo.</p>
+                    </div>
+                    <div class="stat-card space-y-2">
+                        <p class="stat-label">Mujeres vs Hombres</p>
+                        <div class="stat-split">
+                            <div class="stat-mini">
+                                <span id="summary-female" class="text-green-300 text-xl font-bold">—</span>
+                                <span class="muted text-xs">Mujeres únicas</span>
+                            </div>
+                            <div class="stat-mini">
+                                <span id="summary-male" class="text-yellow-300 text-xl font-bold">—</span>
+                                <span class="muted text-xs">Hombres únicos</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="stat-card space-y-2">
+                        <p class="stat-label">Participantes por distancia</p>
+                        <div class="stat-split">
+                            <div class="stat-mini">
+                                <span id="summary-1k" class="text-green-300 text-xl font-bold">—</span>
+                                <span class="muted text-xs">Participantes 1K</span>
+                            </div>
+                            <div class="stat-mini">
+                                <span id="summary-5k" class="text-green-300 text-xl font-bold">—</span>
+                                <span class="muted text-xs">Participantes 5K</span>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
 
-            <div class="bg-gray-800 text-white p-4 rounded-lg shadow-sm border border-gray-700/70 space-y-2">
-                <div class="chart-wrapper h-56">
+            <div class="panel space-y-2">
+                <div class="panel-header">
+                    <div>
+                        <p class="eyebrow mb-1">Evolución por evento</p>
+                        <h2 class="panel-title">Participantes únicos por edición</h2>
+                    </div>
+                    <div class="badge-soft">Participantes únicos</div>
+                </div>
+                <div class="chart-area">
                     <canvas id="chronologyTrendChart" class="chart-canvas"></canvas>
+                    <div class="chart-callout">
+                        <p id="trend-callout-delta" class="callout-value">—</p>
+                        <p id="trend-callout-label" class="callout-label">Última variación registrada</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="panel space-y-3">
+                <div class="panel-header flex-wrap gap-3">
+                    <div>
+                        <p class="eyebrow mb-1">Ritmos populares</p>
+                        <h2 class="panel-title">¿Dónde fue más popular su tiempo?</h2>
+                    </div>
+                    <div class="flex items-center gap-2 flex-wrap">
+                        <div class="flex gap-2" role="group" aria-label="Seleccionar distancia">
+                            <button type="button" data-distance-toggle="1K" class="filter-toggle active">1K</button>
+                            <button type="button" data-distance-toggle="5K" class="filter-toggle">5K</button>
+                        </div>
+                        <div class="flex gap-2" role="group" aria-label="Seleccionar género">
+                            <button type="button" data-gender-toggle="combined" class="filter-toggle active">Combinado</button>
+                            <button type="button" data-gender-toggle="female" class="filter-toggle">Mujeres</button>
+                            <button type="button" data-gender-toggle="male" class="filter-toggle">Hombres</button>
+                        </div>
+                    </div>
+                </div>
+                <p id="chronologyTimeStatus" class="muted text-xs hidden">—</p>
+                <div class="chart-wrapper chart-canvas-compact">
+                    <canvas id="chronologyTimeChart" class="chart-canvas"></canvas>
                 </div>
             </div>
         </div>
 
         <div class="space-y-4">
-            <div class="bg-gray-800 p-4 rounded-lg shadow-sm border border-gray-700/70 space-y-3">
-                <p class="text-[10px] uppercase text-green-400 font-semibold tracking-wide">Filtros</p>
-                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+            <div class="panel space-y-3">
+                <div class="panel-header">
                     <div>
-                        <label for="chronologyEventFilter" class="block text-xs font-medium text-white mb-1">Evento</label>
+                        <p class="eyebrow mb-1">Filtros</p>
+                        <h2 class="panel-title">Vista dinámica de participantes</h2>
+                    </div>
+                    <button id="resetChronologyFilters" type="button" class="pill-button text-sm">Limpiar filtros</button>
+                </div>
+                <div class="filter-grid">
+                    <div class="space-y-1">
+                        <label for="chronologyEventFilter" class="text-xs font-medium text-white">Evento</label>
                         <select id="chronologyEventFilter" class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400"></select>
                     </div>
-                    <div>
-                        <label for="chronologyGenderFilter" class="block text-xs font-medium text-white mb-1">Sexo</label>
+                    <div class="space-y-1">
+                        <label for="chronologyGenderFilter" class="text-xs font-medium text-white">Sexo</label>
                         <select id="chronologyGenderFilter" class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400">
                             <option value="">Todos</option>
                         </select>
                     </div>
-                    <div>
-                        <label for="chronologyCategoryFilter" class="block text-xs font-medium text-white mb-1">Categoría de edad</label>
+                    <div class="space-y-1">
+                        <label for="chronologyCategoryFilter" class="text-xs font-medium text-white">Categoría de edad</label>
                         <select id="chronologyCategoryFilter" class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400">
                             <option value="">Todas</option>
                         </select>
                     </div>
                 </div>
-                <div class="flex items-center justify-between gap-2 flex-wrap text-[11px] text-gray-300" id="activeFiltersSummary"></div>
-            </div>
-
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-                <div class="bg-gray-800 p-3 rounded-lg border border-gray-700/70">
-                    <p class="text-[10px] text-gray-400 uppercase">Mujeres únicas</p>
-                    <p id="summary-female" class="text-2xl font-bold text-green-400 mt-1 leading-tight">—</p>
-                </div>
-                <div class="bg-gray-800 p-3 rounded-lg border border-gray-700/70">
-                    <p class="text-[10px] text-gray-400 uppercase">Hombres únicos</p>
-                    <p id="summary-male" class="text-2xl font-bold text-green-400 mt-1 leading-tight">—</p>
-                </div>
-            </div>
-
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-                <div class="bg-gray-800 p-3 rounded-lg border border-gray-700/70">
-                    <p class="text-[10px] text-gray-400 uppercase">Participantes 1K</p>
-                    <p id="summary-1k" class="text-2xl font-bold text-green-400 mt-1 leading-tight">—</p>
-                </div>
-                <div class="bg-gray-800 p-3 rounded-lg border border-gray-700/70">
-                    <p class="text-[10px] text-gray-400 uppercase">Participantes 5K</p>
-                    <p id="summary-5k" class="text-2xl font-bold text-green-400 mt-1 leading-tight">—</p>
+                <div id="activeFiltersSummary" class="flex items-center justify-between gap-2 flex-wrap text-[11px] text-gray-300"></div>
+                <div class="stat-band">
+                    <div class="stat-pill">
+                        <p class="stat-label">Participantes filtrados</p>
+                        <p id="filtered-participants" class="stat-value text-green-300">—</p>
+                    </div>
+                    <div class="stat-pill">
+                        <p class="stat-label">Mujeres</p>
+                        <p id="filtered-female" class="stat-value text-green-300">—</p>
+                    </div>
+                    <div class="stat-pill">
+                        <p class="stat-label">Hombres</p>
+                        <p id="filtered-male" class="stat-value text-yellow-300">—</p>
+                    </div>
                 </div>
             </div>
 
-            <div class="bg-gray-800 text-white p-4 rounded-lg shadow-sm border border-gray-700/70 space-y-2">
-                <p class="text-[10px] text-green-400 font-semibold uppercase tracking-wide">Edades de participantes únicos</p>
+            <div class="panel space-y-3">
+                <div class="panel-header">
+                    <div>
+                        <p class="eyebrow mb-1">Participantes</p>
+                        <h2 class="panel-title">Candidatos coincidentes</h2>
+                    </div>
+                    <div class="badge-soft">
+                        <span class="text-xs uppercase tracking-wide">Total</span>
+                        <span id="chronologyParticipantsCount" class="text-lg font-extrabold">—</span>
+                    </div>
+                </div>
+                <div id="chronologyParticipantsList" class="chip-grid"></div>
+            </div>
+
+            <div class="panel space-y-2">
+                <div>
+                    <p class="eyebrow mb-1">Distribución por edades</p>
+                    <h2 class="panel-title">Edades de participantes únicos</h2>
+                </div>
                 <div class="chart-wrapper h-56">
                     <canvas id="chronologyAgeChart" class="chart-canvas"></canvas>
-                </div>
-            </div>
-
-            <div class="bg-gray-800 text-white p-4 rounded-lg shadow-sm border border-gray-700/70 space-y-3">
-                <div class="flex items-center justify-between flex-wrap gap-2">
-                    <div class="flex gap-2" role="group" aria-label="Seleccionar distancia">
-                        <button type="button" data-distance-toggle="1K" class="filter-toggle active">1K</button>
-                        <button type="button" data-distance-toggle="5K" class="filter-toggle">5K</button>
-                    </div>
-                    <div class="flex gap-2" role="group" aria-label="Seleccionar género">
-                        <button type="button" data-gender-toggle="combined" class="filter-toggle active">Combinado</button>
-                        <button type="button" data-gender-toggle="female" class="filter-toggle">Mujeres</button>
-                        <button type="button" data-gender-toggle="male" class="filter-toggle">Hombres</button>
-                    </div>
-                </div>
-                <p id="chronologyTimeStatus" class="text-xs text-gray-400 hidden">—</p>
-                <div class="chart-wrapper h-48">
-                    <canvas id="chronologyTimeChart" class="chart-canvas"></canvas>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Reorganiza la página de inicio con un tablero inspirado en el diseño de referencia, sumando nuevas tarjetas de métricas, listados de participantes y paneles dedicados a filtros.
- Ajusta el estilo global con fondo degradado, paneles tipo glassmorphism y etiquetas visuales para resaltar métricas y gráficos clave.
- Actualiza la lógica de cronología con cálculos de crecimiento por evento, formateo de cifras y control para limpiar filtros sin recargar la vista.

## Testing
- No tests were run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945b5e39edc832cb6a8d60754a647b5)