### PR TITLE
Simplify inicio dashboard layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -393,10 +393,19 @@ footer {
     padding: 1.5rem;
 }
 
+.dashboard-compact {
+    max-width: 1200px;
+    padding: 1rem;
+}
+
 .dashboard-grid {
     display: grid;
     grid-template-columns: 1.7fr 1fr;
     gap: 1rem;
+}
+
+.dashboard-compact .dashboard-grid {
+    gap: 0.75rem;
 }
 
 .panel {
@@ -414,6 +423,14 @@ footer {
     justify-content: space-between;
     gap: 1rem;
     margin-bottom: 0.75rem;
+}
+
+.dashboard-compact .panel {
+    padding: 1rem;
+}
+
+.dashboard-compact .panel-header {
+    margin-bottom: 0.5rem;
 }
 
 .panel-title {
@@ -467,7 +484,7 @@ footer {
 .stat-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 0.75rem;
+    gap: 0.65rem;
     margin-top: 1rem;
 }
 
@@ -547,6 +564,10 @@ footer {
 .chart-area {
     position: relative;
     height: 320px;
+}
+
+.dashboard-compact .chart-area {
+    height: 260px;
 }
 
 .chart-callout {

--- a/inicio.html
+++ b/inicio.html
@@ -1,5 +1,5 @@
-<div class="dashboard-shell space-y-4">
-    <section class="dashboard-grid pt-4 items-start">
+<div class="dashboard-shell dashboard-compact space-y-3">
+    <section class="dashboard-grid pt-2 items-start">
         <div class="space-y-4">
             <div class="panel hero-card">
                 <div class="panel-header">
@@ -18,14 +18,6 @@
                         <p class="stat-label">Participantes únicos</p>
                         <p id="summary-participants" class="stat-value large">—</p>
                         <p class="muted text-xs">Sin duplicados por edición.</p>
-                    </div>
-                    <div class="stat-card space-y-1">
-                        <p class="stat-label">Variación último evento</p>
-                        <div class="flex items-center gap-2">
-                            <p id="summary-growth-count" class="stat-value text-green-300">—</p>
-                            <span id="summary-growth-percent" class="stat-compare">—</span>
-                        </div>
-                        <p id="summary-growth-context" class="muted text-xs">En comparación con el evento previo.</p>
                     </div>
                     <div class="stat-card space-y-2">
                         <p class="stat-label">Mujeres vs Hombres</p>
@@ -56,20 +48,9 @@
                 </div>
             </div>
 
-            <div class="panel space-y-2">
-                <div class="panel-header">
-                    <div>
-                        <p class="eyebrow mb-1">Evolución por evento</p>
-                        <h2 class="panel-title">Participantes únicos por edición</h2>
-                    </div>
-                    <div class="badge-soft">Participantes únicos</div>
-                </div>
+            <div class="panel">
                 <div class="chart-area">
                     <canvas id="chronologyTrendChart" class="chart-canvas"></canvas>
-                    <div class="chart-callout">
-                        <p id="trend-callout-delta" class="callout-value">—</p>
-                        <p id="trend-callout-label" class="callout-label">Última variación registrada</p>
-                    </div>
                 </div>
             </div>
 
@@ -140,20 +121,6 @@
                         <p id="filtered-male" class="stat-value text-yellow-300">—</p>
                     </div>
                 </div>
-            </div>
-
-            <div class="panel space-y-3">
-                <div class="panel-header">
-                    <div>
-                        <p class="eyebrow mb-1">Participantes</p>
-                        <h2 class="panel-title">Candidatos coincidentes</h2>
-                    </div>
-                    <div class="badge-soft">
-                        <span class="text-xs uppercase tracking-wide">Total</span>
-                        <span id="chronologyParticipantsCount" class="text-lg font-extrabold">—</span>
-                    </div>
-                </div>
-                <div id="chronologyParticipantsList" class="chip-grid"></div>
             </div>
 
             <div class="panel space-y-2">


### PR DESCRIPTION
## Summary
- streamline the inicio dashboard by removing growth and participant listing tiles
- reduce chart framing and spacing so the view fits without scrolling
- add compact dashboard styling for a tighter layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a2e583468832ca27446dd179f6d8d)