### PR TITLE
Simplify panorama layout and chart labels

### DIFF
--- a/assets/scripts/app.js
+++ b/assets/scripts/app.js
@@ -985,12 +985,19 @@ const aggregateParticipantsByEvent = (records) => {
     });
 
     return Array.from(eventMap.values())
-        .map(event => ({
-            label: event.label,
-            year: event.year,
-            edition: event.edition,
-            count: event.participants.size
-        }))
+        .map(event => {
+            const editionLabel = event.edition ? `${event.edition}°` : null;
+            const yearLabel = event.year || 'Año N/D';
+            const compactLabel = editionLabel ? `${editionLabel}, ${yearLabel}` : `${yearLabel}`;
+
+            return {
+                label: event.label,
+                compactLabel,
+                year: event.year,
+                edition: event.edition,
+                count: event.participants.size
+            };
+        })
         .sort((a, b) => {
             if (a.edition !== b.edition) return a.edition - b.edition;
             if (a.year !== b.year) return a.year - b.year;
@@ -1808,10 +1815,12 @@ const renderEventTrendChart = (data) => {
 
     if (!data.length) return;
 
+    const labels = data.map(item => item.compactLabel || item.label);
+
     yearTrendChartInstance = new Chart(canvas.getContext('2d'), {
         type: 'line',
         data: {
-            labels: data.map(item => item.label),
+            labels,
             datasets: [{
                 label: 'Participantes únicos por evento',
                 data: data.map(item => item.count),
@@ -1830,6 +1839,10 @@ const renderEventTrendChart = (data) => {
                 legend: { display: false },
                 tooltip: {
                     callbacks: {
+                        title: context => {
+                            const index = context[0]?.dataIndex ?? 0;
+                            return data[index]?.label || context[0]?.label || '';
+                        },
                         label: context => `${formatNumber(context.parsed.y)} participantes`
                     }
                 }
@@ -1848,7 +1861,7 @@ const renderEventTrendChart = (data) => {
                 x: {
                     ticks: {
                         color: '#e2e8f0',
-                        font: { size: 13 }
+                        font: { size: 12 }
                     }
                 }
             }

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -415,6 +415,11 @@ footer {
     align-items: stretch;
 }
 
+.merged-insights {
+    grid-template-columns: 1.35fr 1fr 1fr;
+    gap: 0.85rem;
+}
+
 .panel {
     background: linear-gradient(135deg, rgba(30, 41, 59, 0.85), rgba(17, 24, 39, 0.8));
     border: 1px solid rgba(255, 255, 255, 0.05);
@@ -504,14 +509,20 @@ footer {
 }
 
 .stat-card.highlight {
-    background: linear-gradient(145deg, #16a34a, #34d399);
-    color: #0f172a;
-    border-color: rgba(15, 23, 42, 0.2);
-    box-shadow: 0 10px 25px rgba(52, 211, 153, 0.25);
+    background: radial-gradient(circle at 25% 20%, rgba(34, 197, 94, 0.35), rgba(79, 70, 229, 0.45));
+    color: #f8fafc;
+    border-color: rgba(255, 255, 255, 0.14);
+    box-shadow: 0 10px 25px rgba(79, 70, 229, 0.25);
 }
 
-.stat-card.highlight .muted {
-    color: #0f172a;
+.stat-card.highlight .muted,
+.stat-card.highlight .stat-label {
+    color: #e5e7eb;
+}
+
+.stat-card.highlight .stat-value,
+.stat-card.highlight .stat-mini span:first-child {
+    color: #fff;
 }
 
 .stat-label {
@@ -566,6 +577,11 @@ footer {
 .stat-mini span:first-child {
     font-weight: 700;
     color: #e5e7eb;
+}
+
+.merged-summary {
+    display: grid;
+    grid-template-rows: auto auto 1fr;
 }
 
 .chart-area {

--- a/pages/panorama-general.html
+++ b/pages/panorama-general.html
@@ -11,82 +11,46 @@
                 <span id="summary-events" class="text-lg font-extrabold">—</span>
             </div>
         </div>
-        <div class="panel space-y-3 bg-transparent shadow-none p-0">
-            <div class="panel-header px-0">
-                <div>
-                    <p class="eyebrow mb-1">Filtros</p>
-                    <h2 class="panel-title">Vista dinámica de participantes</h2>
-                </div>
-                <button id="resetChronologyFilters" type="button" class="pill-button text-sm">Limpiar filtros</button>
-            </div>
-            <div class="filter-grid">
-                <div class="space-y-1">
-                    <label for="chronologyEventFilter" class="text-xs font-medium text-white">Evento</label>
-                    <select id="chronologyEventFilter" class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400"></select>
-                </div>
-                <div class="space-y-1">
-                    <label for="chronologyGenderFilter" class="text-xs font-medium text-white">Sexo</label>
-                    <select id="chronologyGenderFilter" class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400">
-                        <option value="">Todos</option>
-                    </select>
-                </div>
-                <div class="space-y-1">
-                    <label for="chronologyCategoryFilter" class="text-xs font-medium text-white">Categoría de edad</label>
-                    <select id="chronologyCategoryFilter" class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400">
-                        <option value="">Todas</option>
-                    </select>
-                </div>
-            </div>
-            <div id="activeFiltersSummary" class="flex items-center justify-between gap-2 flex-wrap text-[11px] text-gray-300"></div>
-        </div>
     </div>
 
-    <div class="panel space-y-3">
-        <div class="panel-header">
-            <div>
-                <p class="eyebrow mb-1">Resumen</p>
-                <h2 class="panel-title">Participantes y composición</h2>
-            </div>
-        </div>
-        <div class="stat-grid">
-            <div class="stat-card highlight space-y-1">
-                <p class="stat-label">Participantes únicos</p>
-                <p id="summary-participants" class="stat-value large">—</p>
-                <p class="muted text-xs">Sin duplicados por edición.</p>
-            </div>
-            <div class="stat-card space-y-2">
-                <p class="stat-label">Mujeres vs Hombres</p>
-                <div class="stat-split">
-                    <div class="stat-mini">
-                        <span id="summary-female" class="text-green-300 text-xl font-bold">—</span>
-                        <span class="muted text-xs">Mujeres únicas</span>
+    <section class="insights-grid items-stretch merged-insights">
+        <div class="panel merged-summary space-y-4">
+            <div class="stat-grid">
+                <div class="stat-card highlight space-y-1">
+                    <p class="stat-label">Participantes únicos</p>
+                    <p id="summary-participants" class="stat-value large">—</p>
+                    <p class="muted text-xs">Sin duplicados por edición.</p>
+                </div>
+                <div class="stat-card space-y-2">
+                    <p class="stat-label">Mujeres vs Hombres</p>
+                    <div class="stat-split">
+                        <div class="stat-mini">
+                            <span id="summary-female" class="text-green-300 text-xl font-bold">—</span>
+                            <span class="muted text-xs">Mujeres únicas</span>
+                        </div>
+                        <div class="stat-mini">
+                            <span id="summary-male" class="text-yellow-300 text-xl font-bold">—</span>
+                            <span class="muted text-xs">Hombres únicos</span>
+                        </div>
                     </div>
-                    <div class="stat-mini">
-                        <span id="summary-male" class="text-yellow-300 text-xl font-bold">—</span>
-                        <span class="muted text-xs">Hombres únicos</span>
+                </div>
+                <div class="stat-card space-y-2">
+                    <p class="stat-label">Participantes por distancia</p>
+                    <div class="stat-split">
+                        <div class="stat-mini">
+                            <span id="summary-1k" class="text-green-300 text-xl font-bold">—</span>
+                            <span class="muted text-xs">Participantes 1K</span>
+                        </div>
+                        <div class="stat-mini">
+                            <span id="summary-5k" class="text-green-300 text-xl font-bold">—</span>
+                            <span class="muted text-xs">Participantes 5K</span>
+                        </div>
                     </div>
                 </div>
             </div>
-            <div class="stat-card space-y-2">
-                <p class="stat-label">Participantes por distancia</p>
-                <div class="stat-split">
-                    <div class="stat-mini">
-                        <span id="summary-1k" class="text-green-300 text-xl font-bold">—</span>
-                        <span class="muted text-xs">Participantes 1K</span>
-                    </div>
-                    <div class="stat-mini">
-                        <span id="summary-5k" class="text-green-300 text-xl font-bold">—</span>
-                        <span class="muted text-xs">Participantes 5K</span>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <section class="insights-grid items-stretch">
-        <div class="panel">
-            <div class="panel-header">
+            <div class="panel-header pt-2 pb-0">
                 <div>
+                    <p class="eyebrow mb-1">Evolución</p>
                     <h2 class="panel-title">Participantes por edición</h2>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- remove filter and summary wrappers to focus panorama on key stats and charts
- restyle highlight card and reorganize stats alongside charts for a compact layout
- shorten participant-per-edition chart labels and clarify tooltips

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eaaa8256c832c88c68476efb0424d)