### PR TITLE
Improve panorama layout and chart readability

### DIFF
--- a/assets/scripts/app.js
+++ b/assets/scripts/app.js
@@ -18,6 +18,17 @@ const extractYearFromEvent = (eventString = '') => {
     return match ? match[0] : 'Año N/D';
 };
 
+const formatShortEventLabel = (edition, year, fallback = 'Evento') => {
+    const editionValue = Number.isFinite(edition) ? edition : parseInt(edition, 10);
+    const editionLabel = editionValue && !Number.isNaN(editionValue) ? `${editionValue}°` : null;
+    const yearLabel = year && !Number.isNaN(year) ? year : null;
+
+    if (editionLabel && yearLabel) return `${editionLabel}, ${yearLabel}`;
+    if (editionLabel) return editionLabel;
+    if (yearLabel) return `${yearLabel}`;
+    return fallback;
+};
+
 const parseEventInfo = (eventString = '') => {
     const eventPattern = /id=(\d+)_([\d]+)_marat[oó]n_acapulco_(\d{4})/i;
     const match = eventString.match(eventPattern);
@@ -986,7 +997,7 @@ const aggregateParticipantsByEvent = (records) => {
 
     return Array.from(eventMap.values())
         .map(event => ({
-            label: event.label,
+            label: formatShortEventLabel(event.edition, event.year, event.label),
             year: event.year,
             edition: event.edition,
             count: event.participants.size
@@ -1813,13 +1824,14 @@ const renderEventTrendChart = (data) => {
         data: {
             labels: data.map(item => item.label),
             datasets: [{
-                label: 'Participantes únicos por evento',
+                label: 'Participantes únicos',
                 data: data.map(item => item.count),
-                borderColor: '#48bb78',
-                backgroundColor: 'rgba(72, 187, 120, 0.2)',
+                borderColor: '#22d3ee',
+                backgroundColor: 'rgba(34, 211, 238, 0.2)',
                 tension: 0.3,
                 fill: true,
                 pointRadius: 5,
+                pointBackgroundColor: '#38bdf8',
                 pointHoverRadius: 7
             }]
         },
@@ -1827,7 +1839,11 @@ const renderEventTrendChart = (data) => {
             responsive: true,
             maintainAspectRatio: false,
             plugins: {
-                legend: { display: false },
+                legend: {
+                    labels: {
+                        color: '#e2e8f0'
+                    }
+                },
                 tooltip: {
                     callbacks: {
                         label: context => `${formatNumber(context.parsed.y)} participantes`

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -410,9 +410,13 @@ footer {
 
 .insights-grid {
     display: grid;
-    grid-template-columns: 1.2fr 1fr 1.1fr;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     gap: 1rem;
     align-items: stretch;
+}
+
+.insights-grid-combined .wide-card {
+    grid-column: span 2;
 }
 
 .panel {
@@ -671,7 +675,13 @@ footer {
     }
 
     .insights-grid {
-        grid-template-columns: 1fr;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    }
+}
+
+@media (max-width: 900px) {
+    .insights-grid-combined .wide-card {
+        grid-column: span 1;
     }
 }
 

--- a/pages/panorama-general.html
+++ b/pages/panorama-general.html
@@ -13,10 +13,7 @@
         </div>
         <div class="panel space-y-3 bg-transparent shadow-none p-0">
             <div class="panel-header px-0">
-                <div>
-                    <p class="eyebrow mb-1">Filtros</p>
-                    <h2 class="panel-title">Vista dinámica de participantes</h2>
-                </div>
+                <div></div>
                 <button id="resetChronologyFilters" type="button" class="pill-button text-sm">Limpiar filtros</button>
             </div>
             <div class="filter-grid">
@@ -41,49 +38,43 @@
         </div>
     </div>
 
-    <div class="panel space-y-3">
-        <div class="panel-header">
-            <div>
-                <p class="eyebrow mb-1">Resumen</p>
-                <h2 class="panel-title">Participantes y composición</h2>
-            </div>
-        </div>
-        <div class="stat-grid">
-            <div class="stat-card highlight space-y-1">
-                <p class="stat-label">Participantes únicos</p>
-                <p id="summary-participants" class="stat-value large">—</p>
-                <p class="muted text-xs">Sin duplicados por edición.</p>
-            </div>
-            <div class="stat-card space-y-2">
-                <p class="stat-label">Mujeres vs Hombres</p>
-                <div class="stat-split">
-                    <div class="stat-mini">
-                        <span id="summary-female" class="text-green-300 text-xl font-bold">—</span>
-                        <span class="muted text-xs">Mujeres únicas</span>
-                    </div>
-                    <div class="stat-mini">
-                        <span id="summary-male" class="text-yellow-300 text-xl font-bold">—</span>
-                        <span class="muted text-xs">Hombres únicos</span>
+    <section class="insights-grid items-stretch insights-grid-combined">
+        <div class="panel space-y-3 wide-card">
+            <div class="stat-grid">
+                <div class="stat-card highlight space-y-1">
+                    <p class="stat-label">Participantes únicos</p>
+                    <p id="summary-participants" class="stat-value large">—</p>
+                    <p class="muted text-xs">Sin duplicados por edición.</p>
+                </div>
+                <div class="stat-card space-y-2">
+                    <p class="stat-label">Mujeres vs Hombres</p>
+                    <div class="stat-split">
+                        <div class="stat-mini">
+                            <span id="summary-female" class="text-green-300 text-xl font-bold">—</span>
+                            <span class="muted text-xs">Mujeres únicas</span>
+                        </div>
+                        <div class="stat-mini">
+                            <span id="summary-male" class="text-yellow-300 text-xl font-bold">—</span>
+                            <span class="muted text-xs">Hombres únicos</span>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <div class="stat-card space-y-2">
-                <p class="stat-label">Participantes por distancia</p>
-                <div class="stat-split">
-                    <div class="stat-mini">
-                        <span id="summary-1k" class="text-green-300 text-xl font-bold">—</span>
-                        <span class="muted text-xs">Participantes 1K</span>
-                    </div>
-                    <div class="stat-mini">
-                        <span id="summary-5k" class="text-green-300 text-xl font-bold">—</span>
-                        <span class="muted text-xs">Participantes 5K</span>
+                <div class="stat-card space-y-2">
+                    <p class="stat-label">Participantes por distancia</p>
+                    <div class="stat-split">
+                        <div class="stat-mini">
+                            <span id="summary-1k" class="text-green-300 text-xl font-bold">—</span>
+                            <span class="muted text-xs">Participantes 1K</span>
+                        </div>
+                        <div class="stat-mini">
+                            <span id="summary-5k" class="text-green-300 text-xl font-bold">—</span>
+                            <span class="muted text-xs">Participantes 5K</span>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
-    </div>
 
-    <section class="insights-grid items-stretch">
         <div class="panel">
             <div class="panel-header">
                 <div>


### PR DESCRIPTION
## Summary
- remove filter and summary headers and combine stats with the chart area into a unified grid
- adjust grid styling for the combined layout and responsive behavior
- simplify event labels and update participant trend colors so the legend is readable

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eb460e3b0832c9c3e908b3c32c0e0)