### PR TITLE
Reorganize panorama general layout

### DIFF
--- a/assets/scripts/app.js
+++ b/assets/scripts/app.js
@@ -1904,6 +1904,7 @@ async function initializeChronology() {
 
             setTextContent('summary-events', formatNumber(uniqueEventsCount || 0));
             setTextContent('summary-participants', formatNumber(genderSummary.totalUnique || 0));
+            setTextContent('summary-participants-hero', formatNumber(genderSummary.totalUnique || 0));
             setTextContent('summary-female', formatNumber(genderSummary.femaleCount || 0));
             setTextContent('summary-male', formatNumber(genderSummary.maleCount || 0));
             setTextContent('summary-1k', formatNumber(oneKParticipants || 0));
@@ -1993,7 +1994,6 @@ async function initializeChronology() {
         const genderSelect = document.getElementById('chronologyGenderFilter');
         const categorySelect = document.getElementById('chronologyCategoryFilter');
         const timeStatus = document.getElementById('chronologyTimeStatus');
-        const resetFiltersButton = document.getElementById('resetChronologyFilters');
         const distanceToggleButtons = document.querySelectorAll('[data-distance-toggle]');
         const genderToggleButtons = document.querySelectorAll('[data-gender-toggle]');
         const activeFiltersSummary = document.getElementById('activeFiltersSummary');

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -492,6 +492,42 @@ footer {
     pointer-events: none;
 }
 
+.hero-header {
+    align-items: flex-start;
+}
+
+.hero-highlights {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.hero-metric {
+    background: rgba(15, 23, 42, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 14px;
+    padding: 0.65rem 0.9rem;
+    min-width: 170px;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.hero-metric-label {
+    font-size: 0.7rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: #9ca3af;
+    margin: 0 0 0.15rem;
+}
+
+.hero-metric-value {
+    font-size: 1.9rem;
+    font-weight: 800;
+    color: #a7f3d0;
+    line-height: 1.1;
+}
+
 .stat-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -669,6 +705,26 @@ footer {
     height: 260px;
 }
 
+.panorama-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-areas:
+        "stats filters age"
+        "trend trend trend"
+        "pace pace pace";
+    gap: 1rem;
+}
+
+.panorama-grid .stat-panel { grid-area: stats; }
+.panorama-grid .filter-panel { grid-area: filters; }
+.panorama-grid .age-panel { grid-area: age; }
+.panorama-grid .trend-panel { grid-area: trend; }
+.panorama-grid .pace-panel { grid-area: pace; }
+
+.panorama-grid .panel-header.pb-0 {
+    margin-bottom: 0;
+}
+
 @media (max-width: 1200px) {
     .dashboard-grid {
         grid-template-columns: 1fr;
@@ -677,11 +733,29 @@ footer {
     .insights-grid {
         grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
     }
+
+    .panorama-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        grid-template-areas:
+            "stats filters"
+            "age trend"
+            "pace trend";
+    }
 }
 
 @media (max-width: 900px) {
     .insights-grid-combined .wide-card {
         grid-column: span 1;
+    }
+
+    .panorama-grid {
+        grid-template-columns: 1fr;
+        grid-template-areas:
+            "stats"
+            "filters"
+            "age"
+            "trend"
+            "pace";
     }
 }
 

--- a/pages/panorama-general.html
+++ b/pages/panorama-general.html
@@ -1,45 +1,29 @@
 <div class="dashboard-shell dashboard-compact space-y-4">
     <div class="panel hero-card">
-        <div class="panel-header">
+        <div class="panel-header hero-header">
             <div class="space-y-1">
                 <p class="eyebrow">Dashboard</p>
                 <h1 class="text-3xl md:text-4xl font-extrabold leading-tight text-white">Maratón Internacional Acapulco</h1>
                 <p class="muted text-sm">Participantes únicos en un vistazo general.</p>
             </div>
-            <div class="badge-soft">
-                <span class="text-xs uppercase tracking-wide">Eventos analizados</span>
-                <span id="summary-events" class="text-lg font-extrabold">—</span>
-            </div>
-        </div>
-        <div class="panel space-y-3 bg-transparent shadow-none p-0">
-            <div class="panel-header px-0">
-                <div></div>
-                <button id="resetChronologyFilters" type="button" class="pill-button text-sm">Limpiar filtros</button>
-            </div>
-            <div class="filter-grid">
-                <div class="space-y-1">
-                    <label for="chronologyEventFilter" class="text-xs font-medium text-white">Evento</label>
-                    <select id="chronologyEventFilter" class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400"></select>
+            <div class="hero-highlights">
+                <div class="badge-soft">
+                    <span class="text-xs uppercase tracking-wide">Eventos analizados</span>
+                    <span id="summary-events" class="text-lg font-extrabold">—</span>
                 </div>
-                <div class="space-y-1">
-                    <label for="chronologyGenderFilter" class="text-xs font-medium text-white">Sexo</label>
-                    <select id="chronologyGenderFilter" class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400">
-                        <option value="">Todos</option>
-                    </select>
-                </div>
-                <div class="space-y-1">
-                    <label for="chronologyCategoryFilter" class="text-xs font-medium text-white">Categoría de edad</label>
-                    <select id="chronologyCategoryFilter" class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400">
-                        <option value="">Todas</option>
-                    </select>
+                <div class="hero-metric">
+                    <p class="hero-metric-label">Participantes únicos</p>
+                    <p id="summary-participants-hero" class="hero-metric-value">—</p>
                 </div>
             </div>
-            <div id="activeFiltersSummary" class="flex items-center justify-between gap-2 flex-wrap text-[11px] text-gray-300"></div>
         </div>
     </div>
 
-    <section class="insights-grid items-stretch insights-grid-combined">
-        <div class="panel space-y-3 wide-card">
+    <section class="panorama-grid">
+        <div class="panel space-y-3 stat-panel">
+            <div class="panel-header pb-0">
+                <h2 class="panel-title">Totales destacados</h2>
+            </div>
             <div class="stat-grid">
                 <div class="stat-card highlight space-y-1">
                     <p class="stat-label">Participantes únicos</p>
@@ -75,7 +59,33 @@
             </div>
         </div>
 
-        <div class="panel">
+        <div class="panel space-y-3 filter-panel">
+            <div class="panel-header pb-0">
+                <h2 class="panel-title">Filtros</h2>
+                <p class="muted text-xs">Ajusta el panorama por evento, sexo y categoría.</p>
+            </div>
+            <div class="filter-grid">
+                <div class="space-y-1">
+                    <label for="chronologyEventFilter" class="text-xs font-medium text-white">Evento</label>
+                    <select id="chronologyEventFilter" class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400"></select>
+                </div>
+                <div class="space-y-1">
+                    <label for="chronologyGenderFilter" class="text-xs font-medium text-white">Sexo</label>
+                    <select id="chronologyGenderFilter" class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400">
+                        <option value="">Todos</option>
+                    </select>
+                </div>
+                <div class="space-y-1">
+                    <label for="chronologyCategoryFilter" class="text-xs font-medium text-white">Categoría de edad</label>
+                    <select id="chronologyCategoryFilter" class="w-full p-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400">
+                        <option value="">Todas</option>
+                    </select>
+                </div>
+            </div>
+            <div id="activeFiltersSummary" class="flex items-center justify-between gap-2 flex-wrap text-[11px] text-gray-300"></div>
+        </div>
+
+        <div class="panel trend-panel">
             <div class="panel-header">
                 <div>
                     <h2 class="panel-title">Participantes por edición</h2>
@@ -86,7 +96,7 @@
             </div>
         </div>
 
-        <div class="panel space-y-2">
+        <div class="panel space-y-2 age-panel">
             <div>
                 <p class="eyebrow mb-1">Distribución por edades</p>
             </div>
@@ -95,7 +105,7 @@
             </div>
         </div>
 
-        <div class="panel space-y-3">
+        <div class="panel space-y-3 pace-panel">
             <div class="panel-header flex-wrap gap-3">
                 <div>
                     <p class="eyebrow mb-1">Ritmos populares</p>


### PR DESCRIPTION
## Summary
- highlight total de participantes en la tarjeta principal del dashboard
- reubicar las tarjetas de filtros junto a los totales y reorganizar el grid para mostrar filtros y edades en paralelo
- ajustar estilos para la nueva distribución responsiva

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ebb797b78832cbe86c6e7a3f13585)