### PR TITLE
Add Google Analytics tracking snippet

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,15 @@
     <link rel="stylesheet" href="./assets/styles/main.css">
     <!-- Swiper.js CSS (UMD version) -->
     <link rel="stylesheet" href="https://unpkg.com/swiper@8/swiper-bundle.min.css" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-S0HXWF8GQV"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-S0HXWF8GQV');
+    </script>
     <script src="./assets/scripts/app.js" defer></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>


### PR DESCRIPTION
## Summary
- add Google Analytics gtag snippet to the main index page for site-wide metrics

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ffc5b1cb8832c87a91d01600ebc47)